### PR TITLE
Fix speed attribute not from speed list

### DIFF
--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -329,12 +329,9 @@ class XiaomiGenericDevice(FanEntity):
     async def async_turn_on(self, speed: str = None,
                             **kwargs) -> None:
         """Turn the device on."""
+        result = await self._try_command("Turning the miio device on failed.", self._device.on)
         if speed:
-            # If operation mode was set the device must not be turned on.
-            result = await self.async_set_speed(speed)
-        else:
-            result = await self._try_command(
-                "Turning the miio device on failed.", self._device.on)
+            result = await self.async_set_speed(speed)        
 
         if result:
             self._state = True

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -69,11 +69,11 @@ ATTR_ANGLE = 'angle'
 ATTR_DIRECT_SPEED = 'direct_speed'
 ATTR_USE_TIME = 'use_time'
 ATTR_BUTTON_PRESSED = 'button_pressed'
-ATTR_SPEED_LEVEL = 'speed_level'
+ATTR_RAW_SPEED = 'raw_speed'
 
 AVAILABLE_ATTRIBUTES_FAN = {
     ATTR_ANGLE: 'angle',
-    ATTR_SPEED: 'speed',
+    ATTR_RAW_SPEED: 'speed',
     ATTR_DELAY_OFF_COUNTDOWN: 'delay_off_countdown',
 
     ATTR_AC_POWER: 'ac_power',
@@ -400,7 +400,7 @@ class XiaomiFan(XiaomiGenericDevice):
         self._oscillate = None
         self._natural_mode = False
 
-        self._state_attrs[ATTR_SPEED_LEVEL] = None
+        self._state_attrs[ATTR_SPEED] = None
         self._state_attrs.update(
             {attribute: None for attribute in self._available_attributes})
 
@@ -438,7 +438,7 @@ class XiaomiFan(XiaomiGenericDevice):
                         self._speed = level
                         break
 
-            self._state_attrs[ATTR_SPEED_LEVEL] = self._speed
+            self._state_attrs[ATTR_SPEED] = self._speed
             self._state_attrs.update(
                 {key: self._extract_value_from_attribute(state, value) for
                  key, value in self._available_attributes.items()})


### PR DESCRIPTION
The speed attribute should be from the speed list. However, currently, the speed is the raw speed reported by miio.

![image](https://user-images.githubusercontent.com/666522/65895378-f5a4b300-e3dd-11e9-90d9-4eeaa3823f4b.png)

This patch moves the old speed attribute to a new `raw_speed` attribute, so that the speed is from the speed list.

This fixes several UI issues such as this drop down resetting because the speed is not inside the speed list:

![image](https://user-images.githubusercontent.com/666522/65895517-300e5000-e3de-11e9-8d1b-3c2f00758144.png)

This also fixes homekit component issues in #38
