### PR TITLE
Implementation of scheduled turn off

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,13 +104,13 @@ Set the oscillation angle. Supported values are 30, 60, 90 and 120 degrees.
 
 #### Service `fan.xiaomi_miio_set_delay_off`
 
-Set the scheduled turn off time. Supported values are 60, 120, 180, 240, 300, 360, 420, 480 minutes for dmaker.fan.p5, and 60*60, 120*60, 180*60, 240*60, 300*60, 360*60, 420*60, 480*60 seconds for zhimi.fan.za4 and all others.
+Set the scheduled turn off time. Supported values are 60, 120, 180, 240, 300, 360, 420, 480 minutes.
 
 
 | Service data attribute    | Optional | Description                                                          |
 |---------------------------|----------|----------------------------------------------------------------------|
 | `entity_id`               |      yes | Only act on a specific xiaomi miio entity. Else targets all.         |
-| `delay_off_countdown`     |       no | Time in minutes/seconds. It depends on the type of fan. Valid values are `60`, `120`, `180`, `240`, `300`, `240`, `300`, `360`, `420`, `480` minutes for p5. `3600`, `7200`, `10800`, `14400`, `18000`, `21600`, `25200`, `28800` seconds for zhimi.fan.za4|
+| `delay_off_countdown`     |       no | Time in minutes. Valid values are `60`, `120`, `180`, `240`, `300`, `240`, `300`, `360`, `420`, `480` minutes. |
 
 #### Service `fan.xiaomi_miio_set_natural_mode_on`
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,16 @@ Set the oscillation angle. Supported values are 30, 60, 90 and 120 degrees.
 | `entity_id`               |      yes | Only act on a specific xiaomi miio entity. Else targets all.         |
 | `angle`                   |       no | Angle in degrees. Valid values are `30`, `60`, `90` and `120`.       |
 
+#### Service `fan.xiaomi_miio_set_delay_off`
+
+Set the scheduled turn off time. Supported values are 60, 120, 180, 240, 300, 360, 420, 480 minutes for dmaker.fan.p5, and 60*60, 120*60, 180*60, 240*60, 300*60, 360*60, 420*60, 480*60 seconds for zhimi.fan.za4 and all others.
+
+
+| Service data attribute    | Optional | Description                                                          |
+|---------------------------|----------|----------------------------------------------------------------------|
+| `entity_id`               |      yes | Only act on a specific xiaomi miio entity. Else targets all.         |
+| `delay_off_countdown`     |       no | Time in minutes/seconds. It depends on the type of fan. Valid values are `60`, `120`, `180`, `240`, `300`, `240`, `300`, `360`, `420`, `480` minutes for p5. `3600`, `7200`, `10800`, `14400`, `18000`, `21600`, `25200`, `28800` seconds for zhimi.fan.za4|
+
 #### Service `fan.xiaomi_miio_set_natural_mode_on`
 
 Turn the natural mode on.

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -196,9 +196,7 @@ SERVICE_SCHEMA_OSCILLATION_ANGLE = AIRPURIFIER_SERVICE_SCHEMA.extend(
 )
 
 SERVICE_SCHEMA_DELAY_OFF = AIRPURIFIER_SERVICE_SCHEMA.extend(
-    {vol.Required(ATTR_DELAY_OFF_COUNTDOWN): 
-     vol.All(vol.Coerce(int), vol.In([60, 120, 180, 240, 300, 360, 420, 480, 
-                                      60*60, 120*60, 180*60, 240*60, 300*60, 360*60, 420*60, 480*60]))}
+    {vol.Required(ATTR_DELAY_OFF_COUNTDOWN): vol.All(vol.Coerce(int), vol.In([60, 120, 180, 240, 300, 360, 420, 480]))}
 )
 
 SERVICE_TO_METHOD = {
@@ -630,12 +628,11 @@ class XiaomiFan(XiaomiGenericDevice):
         )
 
     async def async_set_delay_off(self, delay_off_countdown: int) -> None:
-        """Set scheduled off timer in seconds."""
-        
-        seconds = delay_off_countdown
+        """Set scheduled off timer in seconds"""
         
         await self._try_command(
-            "Setting delay off miio device failed.", self._device.delay_off, seconds
+            "Setting delay off miio device failed.", self._device.delay_off, 
+            delay_off_countdown * 60
         )
         
     async def async_set_led_brightness(self, brightness: int = 2):
@@ -786,12 +783,12 @@ class XiaomiFanP5(XiaomiFan):
             self._device.set_mode,
             OperationMode.Normal,
         )
-    
+
     async def async_set_delay_off(self, delay_off_countdown: int) -> None:
-        """Set scheduled off timer in minutes."""
-        
-        minutes = delay_off_countdown
+        """Set scheduled off timer in minutes"""
         
         await self._try_command(
-            "Setting delay off miio device failed.", self._device.delay_off, minutes
+            "Setting delay off miio device failed.", self._device.delay_off, 
+            delay_off_countdown
         )
+    

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -181,6 +181,7 @@ SERVICE_SET_CHILD_LOCK_ON = "xiaomi_miio_set_child_lock_on"
 SERVICE_SET_CHILD_LOCK_OFF = "xiaomi_miio_set_child_lock_off"
 SERVICE_SET_LED_BRIGHTNESS = "xiaomi_miio_set_led_brightness"
 SERVICE_SET_OSCILLATION_ANGLE = "xiaomi_miio_set_oscillation_angle"
+SERVICE_SET_DELAY_OFF = "xiaomi_miio_set_delay_off"
 SERVICE_SET_NATURAL_MODE_ON = "xiaomi_miio_set_natural_mode_on"
 SERVICE_SET_NATURAL_MODE_OFF = "xiaomi_miio_set_natural_mode_off"
 
@@ -192,6 +193,10 @@ SERVICE_SCHEMA_LED_BRIGHTNESS = AIRPURIFIER_SERVICE_SCHEMA.extend(
 
 SERVICE_SCHEMA_OSCILLATION_ANGLE = AIRPURIFIER_SERVICE_SCHEMA.extend(
     {vol.Required(ATTR_ANGLE): vol.All(vol.Coerce(int), vol.In([30, 60, 90, 120]))}
+)
+
+SERVICE_SCHEMA_DELAY_OFF = AIRPURIFIER_SERVICE_SCHEMA.extend(
+    {vol.Required(ATTR_DELAY_OFF_COUNTDOWN): vol.All(vol.Coerce(int), vol.In([60, 120]))}
 )
 
 SERVICE_TO_METHOD = {
@@ -206,6 +211,10 @@ SERVICE_TO_METHOD = {
     SERVICE_SET_OSCILLATION_ANGLE: {
         "method": "async_set_oscillation_angle",
         "schema": SERVICE_SCHEMA_OSCILLATION_ANGLE,
+    },
+    SERVICE_SET_DELAY_OFF: {
+        "method": "async_set_delay_off",
+        "schema": SERVICE_SCHEMA_DELAY_OFF,
     },
     SERVICE_SET_NATURAL_MODE_ON: {"method": "async_set_natural_mode_on"},
     SERVICE_SET_NATURAL_MODE_OFF: {"method": "async_set_natural_mode_off"},

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -196,7 +196,9 @@ SERVICE_SCHEMA_OSCILLATION_ANGLE = AIRPURIFIER_SERVICE_SCHEMA.extend(
 )
 
 SERVICE_SCHEMA_DELAY_OFF = AIRPURIFIER_SERVICE_SCHEMA.extend(
-    {vol.Required(ATTR_DELAY_OFF_COUNTDOWN): vol.All(vol.Coerce(int), vol.In([60, 120]))}
+    {vol.Required(ATTR_DELAY_OFF_COUNTDOWN): 
+     vol.All(vol.Coerce(int), vol.In([60, 120, 180, 240, 300, 360, 420, 480, 
+                                      60*60, 120*60, 180*60, 240*60, 300*60, 360*60, 420*60, 480*60]))}
 )
 
 SERVICE_TO_METHOD = {
@@ -627,9 +629,11 @@ class XiaomiFan(XiaomiGenericDevice):
             "Setting angle of the miio device failed.", self._device.set_angle, angle
         )
 
-    async def async_set_delay_off(self, seconds: int) -> None:
-        """Set delay off seconds."""
-
+    async def async_set_delay_off(self, delay_off_countdown: int) -> None:
+        """Set scheduled off timer in seconds."""
+        
+        seconds = delay_off_countdown
+        
         await self._try_command(
             "Setting delay off miio device failed.", self._device.delay_off, seconds
         )
@@ -781,4 +785,13 @@ class XiaomiFanP5(XiaomiFan):
             "Turning on natural mode of the miio device failed.",
             self._device.set_mode,
             OperationMode.Normal,
+        )
+    
+    async def async_set_delay_off(self, delay_off_countdown: int) -> None:
+        """Set scheduled off timer in minutes."""
+        
+        minutes = delay_off_countdown
+        
+        await self._try_command(
+            "Setting delay off miio device failed.", self._device.delay_off, minutes
         )

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -618,6 +618,13 @@ class XiaomiFan(XiaomiGenericDevice):
             "Setting angle of the miio device failed.", self._device.set_angle, angle
         )
 
+    async def async_set_delay_off(self, seconds: int) -> None:
+        """Set delay off seconds."""
+
+        await self._try_command(
+            "Setting delay off miio device failed.", self._device.delay_off, seconds
+        )
+        
     async def async_set_led_brightness(self, brightness: int = 2):
         """Set the led brightness."""
         if self._device_features & FEATURE_SET_LED_BRIGHTNESS == 0:


### PR DESCRIPTION
Updated docs, and implemented the delay_off call to miio component. 
p5 fan uses minutes, others use seconds. Made change so that it supports both cases.
Set xiaomi_miio_set_delay_off service parameter to accept minutes, because seconds are not readable.