### PR TITLE
Add 140° oscillation for p5 fan

### DIFF
--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -192,7 +192,7 @@ SERVICE_SCHEMA_LED_BRIGHTNESS = AIRPURIFIER_SERVICE_SCHEMA.extend(
 )
 
 SERVICE_SCHEMA_OSCILLATION_ANGLE = AIRPURIFIER_SERVICE_SCHEMA.extend(
-    {vol.Required(ATTR_ANGLE): vol.All(vol.Coerce(int), vol.In([30, 60, 90, 120]))}
+    {vol.Required(ATTR_ANGLE): vol.All(vol.Coerce(int), vol.In([30, 60, 90, 120, 140]))}
 )
 
 SERVICE_SCHEMA_DELAY_OFF = AIRPURIFIER_SERVICE_SCHEMA.extend(
@@ -622,6 +622,8 @@ class XiaomiFan(XiaomiGenericDevice):
         """Set oscillation angle."""
         if self._device_features & FEATURE_SET_OSCILLATION_ANGLE == 0:
             return
+        if angle == 140:
+            return
 
         await self._try_command(
             "Setting angle of the miio device failed.", self._device.set_angle, angle
@@ -782,6 +784,15 @@ class XiaomiFanP5(XiaomiFan):
             "Turning on natural mode of the miio device failed.",
             self._device.set_mode,
             OperationMode.Normal,
+        )
+
+    async def async_set_oscillation_angle(self, angle: int) -> None:
+        """Set oscillation angle."""
+        if self._device_features & FEATURE_SET_OSCILLATION_ANGLE == 0:
+            return
+
+        await self._try_command(
+            "Setting angle of the miio device failed.", self._device.set_angle, angle
         )
 
     async def async_set_delay_off(self, delay_off_countdown: int) -> None:

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -628,7 +628,7 @@ class XiaomiFan(XiaomiGenericDevice):
         )
 
     async def async_set_delay_off(self, delay_off_countdown: int) -> None:
-        """Set scheduled off timer in seconds"""
+        """Set scheduled off timer in minutes"""
         
         await self._try_command(
             "Setting delay off miio device failed.", self._device.delay_off, 

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -622,8 +622,6 @@ class XiaomiFan(XiaomiGenericDevice):
         """Set oscillation angle."""
         if self._device_features & FEATURE_SET_OSCILLATION_ANGLE == 0:
             return
-        if angle == 140:
-            return
 
         await self._try_command(
             "Setting angle of the miio device failed.", self._device.set_angle, angle
@@ -784,15 +782,6 @@ class XiaomiFanP5(XiaomiFan):
             "Turning on natural mode of the miio device failed.",
             self._device.set_mode,
             OperationMode.Normal,
-        )
-
-    async def async_set_oscillation_angle(self, angle: int) -> None:
-        """Set oscillation angle."""
-        if self._device_features & FEATURE_SET_OSCILLATION_ANGLE == 0:
-            return
-
-        await self._try_command(
-            "Setting angle of the miio device failed.", self._device.set_angle, angle
         )
 
     async def async_set_delay_off(self, delay_off_countdown: int) -> None:


### PR DESCRIPTION
Don't really like how I implemented this, would be glad if you have more elegant idea of the solution to the problem.

P5 fan supports additional 140° oscillation angle. I added it as supported number, and for all other fans, when 140 is being set, it just returns.