### PR TITLE
P5 minor fixes(raw speed and device_features typo)

### DIFF
--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -629,7 +629,7 @@ class XiaomiFan(XiaomiGenericDevice):
         )
 
     async def async_set_delay_off(self, delay_off_countdown: int) -> None:
-        """Set scheduled off timer in minutes"""
+        """Set scheduled off timer in seconds"""
         
         await self._try_command(
             "Setting delay off miio device failed.", self._device.delay_off, 

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -628,7 +628,7 @@ class XiaomiFan(XiaomiGenericDevice):
         )
 
     async def async_set_delay_off(self, delay_off_countdown: int) -> None:
-        """Set scheduled off timer in seconds"""
+        """Set scheduled off timer in minutes"""
         
         await self._try_command(
             "Setting delay off miio device failed.", self._device.delay_off, 

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -119,6 +119,7 @@ AVAILABLE_ATTRIBUTES_FAN_P5 = {
     ATTR_LED: "led",
     ATTR_BUZZER: "buzzer",
     ATTR_CHILD_LOCK: "child_lock",
+    ATTR_RAW_SPEED: "speed",
 }
 
 FAN_SPEED_LEVEL1 = "Level 1"
@@ -672,7 +673,7 @@ class XiaomiFanP5(XiaomiFan):
         """Initialize the fan entity."""
         super().__init__(name, device, model, unique_id, retries)
 
-        self._device_features = FEATURE_FLAGS_FAN
+        self._device_features = FEATURE_FLAGS_FAN_P5
         self._available_attributes = AVAILABLE_ATTRIBUTES_FAN_P5
         self._speed_list = list(FAN_SPEED_LIST)
         self._speed = None


### PR DESCRIPTION
Added raw speed indication for p5 fan.
Also fixed what I believe was a typo - _device_features in XiaomiFanP5 class was using FEATURE_FLAGS_FAN instead of FEATURE_FLAGS_FAN_P5.