### PR TITLE
Rename entity_id examples

### DIFF
--- a/custom_components/xiaomi_miio_fan/services.yaml
+++ b/custom_components/xiaomi_miio_fan/services.yaml
@@ -2,36 +2,36 @@ fan_set_buzzer_on:
   description: Turn the buzzer on.
   fields:
     entity_id:
-      description: Name of the xiaomi miio entity.
-      example: "xiaomi_miio_fan.xiaomi_miio_device"
+      description: Name of the Xiaomi Mi Smart Fan entity.
+      example: "fan.xiaomi_smart_fan"
 
 fan_set_buzzer_off:
   description: Turn the buzzer off.
   fields:
     entity_id:
-      description: Name of the xiaomi miio entity.
-      example: "xiaomi_miio_fan.xiaomi_miio_device"
+      description: Name of the Xiaomi Mi Smart Fan entity.
+      example: "fan.xiaomi_smart_fan"
 
 fan_set_child_lock_on:
   description: Turn the child lock on.
   fields:
     entity_id:
-      description: Name of the xiaomi miio entity.
-      example: "xiaomi_miio_fan.xiaomi_miio_device"
+      description: Name of the Xiaomi Mi Smart Fan entity.
+      example: "fan.xiaomi_smart_fan"
 
 fan_set_child_lock_off:
   description: Turn the child lock off.
   fields:
     entity_id:
-      description: Name of the xiaomi miio entity.
-      example: "xiaomi_miio_fan.xiaomi_miio_device"
+      description: Name of the Xiaomi Mi Smart Fan entity.
+      example: "fan.xiaomi_smart_fan"
 
 fan_set_led_brightness:
   description: Set the led brightness.
   fields:
     entity_id:
-      description: Name of the xiaomi miio entity.
-      example: "xiaomi_miio_fan.xiaomi_miio_device"
+      description: Name of the Xiaomi Mi Smart Fan entity.
+      example: "fan.xiaomi_smart_fan"
     brightness:
       description: Brightness (0 = Bright, 1 = Dim, 2 = Off)
       example: 1
@@ -40,22 +40,22 @@ fan_set_natural_mode_on:
   description: Turn the natural mode on.
   fields:
     entity_id:
-      description: Name of the xiaomi miio entity.
-      example: "xiaomi_miio_fan.xiaomi_miio_device"
+      description: Name of the Xiaomi Mi Smart Fan entity.
+      example: "fan.xiaomi_smart_fan"
 
 fan_set_natural_mode_off:
   description: Turn the natural mode off.
   fields:
     entity_id:
-      description: Name of the xiaomi miio entity.
-      example: "xiaomi_miio_fan.xiaomi_miio_device"
+      description: Name of the Xiaomi Mi Smart Fan entity.
+      example: "fan.xiaomi_smart_fan"
 
 fan_set_oscillation_angle:
   description: Set the oscillation angle.
   fields:
     entity_id:
-      description: Name of the xiaomi miio entity.
-      example: "xiaomi_miio_fan.xiaomi_miio_device"
+      description: Name of the Xiaomi Mi Smart Fan entity.
+      example: "fan.xiaomi_smart_fan"
     angle:
       description: Supported values are 30, 60, 90, 120, 140 or 150 degrees.
       example: 30
@@ -64,8 +64,8 @@ fan_set_delay_off:
   description: Set the scheduled turn off time.
   fields:
     entity_id:
-      description: Name of the xiaomi miio entity.
-      example: "xiaomi_miio_fan.xiaomi_miio_device"
+      description: Name of the Xiaomi Mi Smart Fan entity.
+      example: "fan.xiaomi_smart_fan"
     delay_off_countdown:
       description: Time in minutes. Valid values are 0, 60, 120, 180, 240, 300, 240, 300, 360, 420, 480 minutes.
       example: 60


### PR DESCRIPTION
The entity_id in Home Assistant starts with `fan.` and the current examples show `xiaomi_miio_fan.`
This PR changes this for the services.yaml file.