### PR TITLE
Update fan.py

### DIFF
--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -40,9 +40,7 @@ from miio import (  # pylint: disable=import-error
     Fan1C,
     FanLeshow,
     FanP5,
-    FanP9,
-    FanP10,
-    FanP11,
+    FanMiot
 )
 from miio.miot_device import MiotDevice, DeviceStatus
 from miio.fan_common import (


### PR DESCRIPTION
python-miio 0.5.11 (homeassistant 2022.3.3)

The following previously deprecated classes in favor of model-based discovery, if you were using these classes directly you need to adjust your code:

AirFreshVA4 - use AirFresh
AirHumidifierCA1, AirHumidifierCB1, AirHumidifierCB2 - use AirHumidifier
AirDogX5, AirDogX7SM - use AirDogX3
AirPurifierMB4 - use AirPurifierMiot
Plug, PlugV1, PlugV3 - use ChuangmiPlug
FanP9, FanP10, FanP11 - use FanMiot
DreameVacuumMiot - use DreameVacuum
Vacuum - use RoborockVacuum