### PR TITLE
Compute unique_id when model detection is deactivated

### DIFF
--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -399,6 +399,8 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             )
         except DeviceException as ex:
             raise PlatformNotReady from ex
+    else:
+        unique_id = f"{model}-{token}"
 
     if model in [
         MODEL_FAN_V2,


### PR DESCRIPTION
Before this patch, setting `model` in configuration prevented to have a
`unique_id` (which is painful to edit device from home assistant UI).

Fixes #190 

Note: I've not tested the patch yet