### PR TITLE
dmaker.fan.p39: Avoid polling the `motor_control` property to get rid of -4004 errors

### DIFF
--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -2317,7 +2317,7 @@ class FanP39(MiotDevice):
         start_id: int = 0,
         debug: int = 0,
         lazy_discover: bool = True,
-        model: str = MODEL_FAN_P33,
+        model: str = MODEL_FAN_P39,
     ) -> None:
         super().__init__(ip, token, start_id, debug, lazy_discover, model=model)
 

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -2306,7 +2306,6 @@ class FanP39(MiotDevice):
         "oscillate": {"siid": 2, "piid": 5},
         "angle": {"siid": 2, "piid": 6},
         "delay_off_countdown": {"siid": 2, "piid": 8},
-        "motor_control": {"siid": 2, "piid": 10},
         "speed": {"siid": 2, "piid": 11},
         "child_lock": {"siid": 3, "piid": 1},
     }


### PR DESCRIPTION
The `motor_control` property is *write only*, not readable, [according to the spec](https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:fan:0000A005:dmaker-p39:1). And the `mapping` variable is being used to construct the status request to the fan, so the request inappropriately includes this property, resulting in a response with nothing set and the -4004 error code.

I have no idea why it works for some people, maybe they have an earlier firmware in their fan that is not so picky with the request correctness.

This PR makes the integration work for me, and possibly for the other people having problems with this fan model.