### PR TITLE
Include additional sleep mode to dmaker.fan.p39

### DIFF
--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -2256,6 +2256,7 @@ class XiaomiFanP39(XiaomiFanMiot):
 class OperationModeFanP39(Enum):
     Normal = 0
     Nature = 1
+    Sleep = 2
 
 
 class FanStatusP39(DeviceStatus):


### PR DESCRIPTION
The [spec](https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:fan:0000A005:dmaker-p39:1) specifies 3 modes are supported for this device, but only 2 are currently included. This breaks support if the fan is in sleep mode.

This PR adds the missing mode.