### PR TITLE
Fix dmaker.fan.p39 rotate

### DIFF
--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -2311,6 +2311,7 @@ class FanP39(MiotDevice):
         "oscillate": {"siid": 2, "piid": 5},
         "angle": {"siid": 2, "piid": 6},
         "delay_off_countdown": {"siid": 2, "piid": 8},
+        "motor_control": {"siid": 2, "piid": 10, "access": ["write"]},
         "speed": {"siid": 2, "piid": 11},
         "child_lock": {"siid": 3, "piid": 1},
     }


### PR DESCRIPTION
https://github.com/syssi/xiaomi_fan/pull/230 had the side effect of removing support for rotate commands for dmaker.fan.p39.
This PR restores it, backporting and adapting code from current python-miio repo.