### PR TITLE
Fix LED support of the dmaker.fan.1c

### DIFF
--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -517,7 +517,13 @@ FEATURE_FLAGS_FAN_P5 = (
 )
 
 FEATURE_FLAGS_FAN_LESHOW_SS4 = FEATURE_SET_BUZZER
-FEATURE_FLAGS_FAN_1C = FEATURE_FLAGS_FAN
+FEATURE_FLAGS_FAN_1C = (
+    FEATURE_SET_BUZZER
+    | FEATURE_SET_CHILD_LOCK
+    | FEATURE_SET_LED
+    | FEATURE_SET_OSCILLATION_ANGLE
+    | FEATURE_SET_NATURAL_MODE
+)
 
 FEATURE_FLAGS_FAN_ZA5 = (
     FEATURE_SET_BUZZER
@@ -1706,16 +1712,14 @@ class XiaomiFan1C(XiaomiFan):
             delay_off_countdown,
         )
 
-    async def async_set_led_brightness(self, brightness: int = 2):
-        """Set the led brightness."""
-        brightness = FanLedBrightness(brightness)
-        if brightness == FanLedBrightness.Dim:
+    async def async_set_led_brightness(self, brightness: int = 1):
+        """Set LED on (brightness != 2) or off (brightness == 2)."""
+        if self._device_features & FEATURE_SET_LED == 0:
             return
-
         await self._try_command(
-            "Setting the led brightness of the miio device failed.",
+            "Setting LED of the miio device failed.",
             self._device.set_led,
-            brightness == FanLedBrightness.Bright,
+            brightness != 2,
         )
 
     async def async_set_natural_mode_on(self):

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -1712,7 +1712,7 @@ class XiaomiFan1C(XiaomiFan):
             delay_off_countdown,
         )
 
-    async def async_set_led_brightness(self, brightness: int = 1):
+    async def async_set_led_brightness(self, brightness: int = 2):
         """Set LED on (brightness != 2) or off (brightness == 2)."""
         if self._device_features & FEATURE_SET_LED == 0:
             return

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -1706,6 +1706,18 @@ class XiaomiFan1C(XiaomiFan):
             delay_off_countdown,
         )
 
+    async def async_set_led_brightness(self, brightness: int = 2):
+        """Set the led brightness."""
+        brightness = FanLedBrightness(brightness)
+        if brightness == FanLedBrightness.Dim:
+            return
+
+        await self._try_command(
+            "Setting fan natural mode of the miio device failed.",
+            self._device.set_led,
+            brightness == FanLedBrightness.Bright,
+        )
+
     async def async_set_natural_mode_on(self):
         """Turn the natural mode on."""
         if self._device_features & FEATURE_SET_NATURAL_MODE == 0:

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -1713,7 +1713,7 @@ class XiaomiFan1C(XiaomiFan):
             return
 
         await self._try_command(
-            "Setting fan natural mode of the miio device failed.",
+            "Setting the led brightness of the miio device failed.",
             self._device.set_led,
             brightness == FanLedBrightness.Bright,
         )


### PR DESCRIPTION
Quick fix for add ON/OFF Led support for Xiaomi 1C fan
Works pretty well with my fan
on regards to issue: https://github.com/syssi/xiaomi_fan/issues/189 
Unfortunately, I'm not sure about how to add support for other fans with this problem 
