### PR TITLE
Add xiaomi.fan.p70 (Smart Desktop Air Circulation Fan) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Credits: Thanks to [Rytilahti](https://github.com/rytilahti/python-miio) for all
 | Rosou SS4 Ventilator        | leshow.fan.ss4         | | |
 | Xiaomi Smart Tower Fan      | dmaker.fan.p39         | BPTS01DM | 22W, <=63dB |
 | Xiaomi Smart Standing Air Circulation Fan | xiaomi.fan.p76 | JLLDS01XY | - |
+| Xiaomi Smart Desktop Air Circulation Fan  | xiaomi.fan.p70 | - | - |
 
 
 ## Features

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -65,6 +65,7 @@ MODEL_FAN_P30 = "dmaker.fan.p30"  # Mi Smart Standing Fan 2 P30
 MODEL_FAN_P33 = "dmaker.fan.p33"  # Mi Smart Standing Fan Pro 2
 MODEL_FAN_P39 = "dmaker.fan.p39"  # Smart Tower Fan
 MODEL_FAN_P76 = "xiaomi.fan.p76"  # Xiaomi Smart Standing Air Circulation Fan
+MODEL_FAN_P70 = "xiaomi.fan.p70"  # Smart Desktop Air Circulation Fan
 MODEL_FAN_LESHOW_SS4 = "leshow.fan.ss4"
 MODEL_FAN_1C = "dmaker.fan.1c"  # Pedestal Fan Fan 1C
 
@@ -93,6 +94,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
                 MODEL_FAN_P33,
                 MODEL_FAN_P39,
                 MODEL_FAN_P76,
+                MODEL_FAN_P70,
                 MODEL_FAN_LESHOW_SS4,
                 MODEL_FAN_1C,
             ]
@@ -191,6 +193,19 @@ AVAILABLE_ATTRIBUTES_FAN_P39 = {
 }
 
 AVAILABLE_ATTRIBUTES_FAN_P76 = {
+    ATTR_MODE: "mode",
+    ATTR_OSCILLATE: "horizontal_swing",
+    ATTR_ANGLE: "horizontal_swing_angle",
+    ATTR_VERTICAL_OSCILLATE: "vertical_swing",
+    ATTR_VERTICAL_ANGLE: "vertical_swing_angle",
+    ATTR_DELAY_OFF_COUNTDOWN: "delay_time",
+    ATTR_LED: "led",
+    ATTR_BUZZER: "buzzer",
+    ATTR_CHILD_LOCK: "child_lock",
+    ATTR_RAW_SPEED: "fan_speed",
+}
+
+AVAILABLE_ATTRIBUTES_FAN_P70 = {
     ATTR_MODE: "mode",
     ATTR_OSCILLATE: "horizontal_swing",
     ATTR_ANGLE: "horizontal_swing_angle",
@@ -328,6 +343,16 @@ FAN_PRESET_MODES_P76 = {
 
 FAN_SPEEDS_P76 = [FAN_SPEED_LEVEL1, FAN_SPEED_LEVEL2, FAN_SPEED_LEVEL3, FAN_SPEED_LEVEL4]
 
+FAN_PRESET_MODES_P70 = {
+    SPEED_OFF: -1,
+    FAN_SPEED_LEVEL1: 0,
+    FAN_SPEED_LEVEL2: 1,
+    FAN_SPEED_LEVEL3: 2,
+    FAN_SPEED_LEVEL4: 3,
+}
+
+FAN_SPEEDS_P70 = [FAN_SPEED_LEVEL1, FAN_SPEED_LEVEL2, FAN_SPEED_LEVEL3, FAN_SPEED_LEVEL4]
+
 SUCCESS = ["ok"]
 
 FEATURE_SET_BUZZER = 1
@@ -380,6 +405,15 @@ FEATURE_FLAGS_FAN_P39 = (
 )
 
 FEATURE_FLAGS_FAN_P76 = (
+    FEATURE_SET_BUZZER
+    | FEATURE_SET_CHILD_LOCK
+    | FEATURE_SET_LED
+    | FEATURE_SET_OSCILLATION_ANGLE
+    | FEATURE_SET_NATURAL_MODE
+    | FEATURE_SET_VERTICAL_OSCILLATION
+)
+
+FEATURE_FLAGS_FAN_P70 = (
     FEATURE_SET_BUZZER
     | FEATURE_SET_CHILD_LOCK
     | FEATURE_SET_LED
@@ -546,6 +580,11 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     elif model == MODEL_FAN_P76:
         fan = FanP76(host, token, model=model)
         device = XiaomiFanP76(
+            name, fan, model, unique_id, retries, preset_modes_override
+        )
+    elif model == MODEL_FAN_P70:
+        fan = FanP70(host, token, model=model)
+        device = XiaomiFanP70(
             name, fan, model, unique_id, retries, preset_modes_override
         )
     else:
@@ -2775,6 +2814,357 @@ class XiaomiFanP76(XiaomiFanP33):
             "Setting fan natural mode of the miio device failed.",
             self._device.set_mode,
             OperationModeFanP76.Straight,
+        )
+
+    async def async_set_vertical_oscillation_on(self):
+        if self._device_features & FEATURE_SET_VERTICAL_OSCILLATION == 0:
+            return
+        await self._try_command(
+            "Setting vertical oscillation on of the miio device failed.",
+            self._device.set_vertical_oscillate,
+            True,
+        )
+
+    async def async_set_vertical_oscillation_off(self):
+        if self._device_features & FEATURE_SET_VERTICAL_OSCILLATION == 0:
+            return
+        await self._try_command(
+            "Setting vertical oscillation off of the miio device failed.",
+            self._device.set_vertical_oscillate,
+            False,
+        )
+
+
+class OperationModeFanP70(Enum):
+    Straight = 0
+    Natural = 1
+
+
+class FanStatusP70(DeviceStatus):
+    """Container for status reports for FanP70."""
+
+    def __init__(self, data: Dict[str, Any]) -> None:
+        self.data = data
+
+    @property
+    def power(self) -> bool:
+        return self.data["power"]
+
+    @property
+    def fault(self) -> int:
+        return self.data["fault"]
+
+    @property
+    def mode(self) -> str:
+        return OperationModeFanP70(self.data["mode"]).name
+
+    @property
+    def fan_level(self) -> int:
+        return self.data["fan_level"]
+
+    @property
+    def fan_speed(self) -> int:
+        return self.data["fan_speed"]
+
+    @property
+    def horizontal_swing(self) -> bool:
+        return self.data["horizontal_swing"]
+
+    @property
+    def horizontal_swing_angle(self) -> int:
+        return self.data["horizontal_swing_angle"]
+
+    @property
+    def vertical_swing(self) -> bool:
+        return self.data["vertical_swing"]
+
+    @property
+    def vertical_swing_angle(self) -> int:
+        return self.data["vertical_swing_angle"]
+
+    @property
+    def led(self) -> bool:
+        return self.data["led"]
+
+    @property
+    def buzzer(self) -> bool:
+        return self.data["buzzer"]
+
+    @property
+    def child_lock(self) -> bool:
+        return self.data["child_lock"]
+
+    @property
+    def delay_time(self) -> int:
+        return self.data["delay_time"]
+
+
+class FanP70(MiotDevice):
+    """Main class representing the Xiaomi Fan P70 (xiaomi.fan.p70)."""
+
+    mapping = {
+        "power":                  {"siid": 2, "piid": 1},
+        "fault":                  {"siid": 2, "piid": 2},
+        "mode":                   {"siid": 2, "piid": 3},
+        "fan_level":              {"siid": 2, "piid": 4},
+        "fan_speed":              {"siid": 2, "piid": 5},
+        "horizontal_swing":       {"siid": 2, "piid": 6},
+        "horizontal_swing_angle": {"siid": 2, "piid": 7},
+        "vertical_swing":         {"siid": 2, "piid": 8},
+        "vertical_swing_angle":   {"siid": 2, "piid": 9},
+        "led":                    {"siid": 5, "piid": 1},
+        "buzzer":                 {"siid": 7, "piid": 1},
+        "child_lock":             {"siid": 8, "piid": 1},
+        "delay_time":             {"siid": 9, "piid": 2},
+    }
+
+    def __init__(
+        self,
+        ip: str = None,
+        token: str = None,
+        start_id: int = 0,
+        debug: int = 0,
+        lazy_discover: bool = True,
+        timeout: int = 5,
+        model: str = MODEL_FAN_P70,
+    ) -> None:
+        super().__init__(ip, token, start_id, debug, lazy_discover, timeout, model=model)
+
+    # backported and adapted from current master
+    def get_properties_for_mapping(self, *, max_properties=15) -> list:
+        """Retrieve raw properties based on mapping."""
+        mapping = self._get_mapping()
+
+        # We send property key in "did" because it's sent back via response and we can identify the property.
+        properties = [
+            {"did": k, **_filter_request_fields(v)}
+            for k, v in mapping.items()
+            if "aiid" not in v and ("access" not in v or "read" in v["access"])
+        ]
+
+        return self.get_properties(
+            properties, property_getter="get_properties", max_properties=max_properties
+        )
+
+    def status(self):
+        """Retrieve properties."""
+        return FanStatusP70(
+            {
+                prop["did"]: prop["value"] if prop["code"] == 0 else None
+                for prop in self.get_properties_for_mapping()
+            }
+        )
+
+    def on(self):
+        """Power on."""
+        return self.set_property("power", True)
+
+    def off(self):
+        """Power off."""
+        return self.set_property("power", False)
+
+    def set_speed(self, speed: int):
+        """Set fan speed (1-100)."""
+        if speed < 1 or speed > 100:
+            raise FanException("Invalid speed: %s" % speed)
+        return self.set_property("fan_speed", speed)
+
+    def set_fan_level(self, level: int):
+        """Set fan level (0-3)."""
+        if level not in [0, 1, 2, 3]:
+            raise FanException("Invalid fan level: %s" % level)
+        return self.set_property("fan_level", level)
+
+    def set_oscillate(self, oscillate: bool):
+        """Set horizontal oscillation on/off."""
+        return self.set_property("horizontal_swing", oscillate)
+
+    def set_vertical_oscillate(self, oscillate: bool):
+        """Set vertical oscillation on/off."""
+        return self.set_property("vertical_swing", oscillate)
+
+    def set_angle(self, angle: int):
+        """Set horizontal oscillation angle."""
+        if angle not in [30, 60, 90, 120]:
+            raise FanException(
+                "Unsupported angle. Supported values: "
+                + ", ".join(str(i) for i in [30, 60, 90, 120])
+            )
+        return self.set_property("horizontal_swing_angle", angle)
+
+    def set_buzzer(self, buzzer: bool):
+        """Set buzzer on/off."""
+        if buzzer:
+            return self.set_property("buzzer", True)
+        else:
+            return self.set_property("buzzer", False)
+
+    def set_child_lock(self, lock: bool):
+        """Set child lock on/off."""
+        return self.set_property("child_lock", lock)
+
+    def set_light(self, light: bool):
+        """Set indicator state."""
+        return self.set_property("led", light)
+
+    def set_mode(self, mode: OperationModeFanP70):
+        """Set mode."""
+        return self.set_property("mode", mode.value)
+
+    def delay_off(self, minutes: int):
+        """Set delay off in minutes (0-480)."""
+        if minutes < 0 or minutes > 480:
+            raise FanException("Invalid value for a delayed turn off: %s" % minutes)
+        return self.set_property("delay_time", minutes)
+
+
+class XiaomiFanP70(XiaomiFanP33):
+    """Representation of a Xiaomi Smart Desktop Air Circulation Fan P70."""
+
+    def __init__(self, name, device, model, unique_id, retries, preset_modes_override):
+        super().__init__(name, device, model, unique_id, retries, preset_modes_override)
+
+        self._device_features = FEATURE_FLAGS_FAN_P70
+        self._available_attributes = AVAILABLE_ATTRIBUTES_FAN_P70
+        self._percentage = None
+        self._preset_modes = list(FAN_PRESET_MODES_P70)
+        if preset_modes_override is not None:
+            self._preset_modes = preset_modes_override
+
+        self._preset_mode = None
+        self._oscillate = None
+        self._vertical_oscillate = None
+        self._natural_mode = False
+
+        self._state_attrs = {
+            ATTR_MODEL: self._model,
+            **{attribute: None for attribute in self._available_attributes},
+        }
+
+    @property
+    def supported_features(self) -> int:
+        return (
+            FanEntityFeature.OSCILLATE
+            | FanEntityFeature.PRESET_MODE
+            | FanEntityFeature.SET_SPEED
+            | FanEntityFeature.TURN_OFF
+            | FanEntityFeature.TURN_ON
+            | FanEntityFeature.DIRECTION
+        )
+
+    @property
+    def current_direction(self) -> str:
+        if self._vertical_oscillate is None:
+            return None
+        return "forward" if self._vertical_oscillate else "reverse"
+
+    async def async_set_direction(self, direction: str) -> None:
+        if direction == "forward":
+            await self.async_set_vertical_oscillation_on()
+            self._vertical_oscillate = True
+        else:
+            await self.async_set_vertical_oscillation_off()
+            self._vertical_oscillate = False
+        self.async_write_ha_state()
+
+    async def async_update(self):
+        if self._skip_update:
+            self._skip_update = False
+            return
+
+        try:
+            state = await self.hass.async_add_executor_job(self._device.status)
+            _LOGGER.debug("Got new state: %s", state)
+
+            self._available = True
+            self._percentage = state.fan_speed
+            self._oscillate = state.horizontal_swing
+            self._vertical_oscillate = state.vertical_swing
+            self._natural_mode = state.mode == OperationModeFanP70.Natural.name
+            self._state = state.power
+
+            for preset_mode, value in FAN_PRESET_MODES_P70.items():
+                if state.fan_level == value:
+                    self._preset_mode = preset_mode
+                    break
+
+            self._state_attrs.update(
+                {
+                    key: self._extract_value_from_attribute(state, value)
+                    for key, value in self._available_attributes.items()
+                    if hasattr(state, value)
+                }
+            )
+            self._retry = 0
+
+        except DeviceException as ex:
+            self._retry = self._retry + 1
+            if self._retry < self._retries:
+                _LOGGER.info(
+                    "%s Got exception while fetching the state: %s , _retry=%s",
+                    self.__class__.__name__,
+                    ex,
+                    self._retry,
+                )
+            else:
+                self._available = False
+                _LOGGER.error(
+                    "%s Got exception while fetching the state: %s , _retry=%s",
+                    self.__class__.__name__,
+                    ex,
+                    self._retry,
+                )
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        _LOGGER.debug("Setting the preset mode to: %s", preset_mode)
+
+        if preset_mode == SPEED_OFF:
+            await self.async_turn_off()
+            return
+
+        if not self._state:
+            await self._try_command(
+                "Turning the miio device on failed.", self._device.on
+            )
+        await self._try_command(
+            "Setting fan level of the miio device failed.",
+            self._device.set_fan_level,
+            FAN_PRESET_MODES_P70[preset_mode],
+        )
+
+    async def async_set_percentage(self, percentage: int) -> None:
+        _LOGGER.debug("Setting the fan speed percentage to: %s", percentage)
+
+        if percentage == 0:
+            await self.async_turn_off()
+            return
+
+        if not self._state:
+            await self._try_command(
+                "Turning the miio device on failed.", self._device.on
+            )
+        await self._try_command(
+            "Setting fan speed percentage of the miio device failed.",
+            self._device.set_speed,
+            percentage,
+        )
+
+    async def async_set_natural_mode_on(self):
+        if self._device_features & FEATURE_SET_NATURAL_MODE == 0:
+            return
+        await self._try_command(
+            "Setting fan natural mode of the miio device failed.",
+            self._device.set_mode,
+            OperationModeFanP70.Natural,
+        )
+
+    async def async_set_natural_mode_off(self):
+        if self._device_features & FEATURE_SET_NATURAL_MODE == 0:
+            return
+        await self._try_command(
+            "Setting fan natural mode of the miio device failed.",
+            self._device.set_mode,
+            OperationModeFanP70.Straight,
         )
 
     async def async_set_vertical_oscillation_on(self):


### PR DESCRIPTION
## Summary

- Add support for `xiaomi.fan.p70` (Xiaomi Smart Desktop Air Circulation Fan)
- Implements `XiaomiFanP70` class extending `XiaomiFanP33` with P70-specific MIoT mapping
- Vertical oscillation exposed via `FanEntityFeature.DIRECTION` (forward = on, reverse = off)
- Reuses `fan_set_vertical_oscillation_on/off` services
- Adds `FanStatusP70`, `FanP70`, `OperationModeFanP70` (Straight=0 / Natural=1)
- Follows same `get_properties_for_mapping` pattern as P76/P39

## Device

| Property | Value |
|---|---|
| Model | `xiaomi.fan.p70` |
| Name | Xiaomi Smart Desktop Air Circulation Fan |
| Protocol | MIoT |

## MIoT mapping (differs from P76)

| Property | siid | piid |
|---|---|---|
| power | 2 | 1 |
| fault | 2 | 2 |
| mode | 2 | 3 |
| fan_level | 2 | 4 |
| fan_speed | 2 | 5 |
| horizontal_swing | 2 | 6 |
| horizontal_swing_angle | 2 | 7 |
| vertical_swing | 2 | 8 |
| vertical_swing_angle | 2 | 9 |
| led | 5 | 1 |
| buzzer | 7 | 1 |
| child_lock | 8 | 1 |
| delay_time | 9 | 2 |

## Changes

- `fan.py`: model constant, attributes, preset modes, feature flags, setup routing, P70 classes
- `README.md`: P70 added to supported devices table

## Test plan

Tested by @RedNo7 against real device:

- [x] Fan turns on/off
- [x] Speed control (percentage slider)
- [x] Preset modes (Level 1–4)
- [x] Horizontal oscillation toggle
- [x] Vertical oscillation toggle (via DIRECTION forward/reverse)
- [x] Natural mode on/off (via `fan_set_natural_mode_on/off` service)
- [ ] Buzzer / child lock / LED (service-controlled, not verified against real device yet)