### PR TITLE
Add service to set the vertical oscillation angle (xiaomi.fan.p76 & xiaomi.fan.p70)

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,22 @@ Turn to the given direction. Supported values are left, right, up and down. (P76
 |---------------------------|----------|----------------------------------------------------------------------|
 | `direction`               |       no | Direction. Valid values are `left`, `right`, `up` and `down`.        |
 
+#### Service `xiaomi_miio_fan.fan_set_vertical_oscillation_on`
+
+Turn the vertical oscillation on. (P70 and P76 only)
+
+| Service data attribute    | Optional | Description                                                          |
+|---------------------------|----------|----------------------------------------------------------------------|
+| `entity_id`               |      yes | Only act on a specific xiaomi miio entity. Else targets all.         |
+
+#### Service `xiaomi_miio_fan.fan_set_vertical_oscillation_off`
+
+Turn the vertical oscillation off. (P70 and P76 only)
+
+| Service data attribute    | Optional | Description                                                          |
+|---------------------------|----------|----------------------------------------------------------------------|
+| `entity_id`               |      yes | Only act on a specific xiaomi miio entity. Else targets all.         |
+
 #### Service `xiaomi_miio_fan.fan_set_vertical_oscillation_angle`
 
 Set the vertical oscillation angle. (P70 and P76 only)

--- a/README.md
+++ b/README.md
@@ -258,3 +258,12 @@ Turn to the given direction. Supported values are left, right, up and down. (P76
 | Service data attribute    | Optional | Description                                                          |
 |---------------------------|----------|----------------------------------------------------------------------|
 | `direction`               |       no | Direction. Valid values are `left`, `right`, `up` and `down`.        |
+
+#### Service `xiaomi_miio_fan.fan_set_vertical_oscillation_angle`
+
+Set the vertical oscillation angle. (P70 and P76 only)
+
+| Service data attribute    | Optional | Description                                                          |
+|---------------------------|----------|----------------------------------------------------------------------|
+| `entity_id`               |      yes | Only act on a specific xiaomi miio entity. Else targets all.         |
+| `vertical_angle`          |       no | Vertical angle in degrees. Valid values are `30`, `60`, `90` and `100`. |

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -374,6 +374,7 @@ FEATURE_SET_NATURAL_MODE = 32
 FEATURE_SET_ANION = 64
 FEATURE_SET_VERTICAL_OSCILLATION = 128
 FEATURE_TURN = 256
+FEATURE_SET_VERTICAL_OSCILLATION_ANGLE = 512
 
 FEATURE_FLAGS_FAN = (
     FEATURE_SET_BUZZER
@@ -423,6 +424,7 @@ FEATURE_FLAGS_FAN_P76 = (
     | FEATURE_SET_NATURAL_MODE
     | FEATURE_SET_VERTICAL_OSCILLATION
     | FEATURE_TURN
+    | FEATURE_SET_VERTICAL_OSCILLATION_ANGLE
 )
 
 FEATURE_FLAGS_FAN_P70 = (
@@ -432,6 +434,7 @@ FEATURE_FLAGS_FAN_P70 = (
     | FEATURE_SET_OSCILLATION_ANGLE
     | FEATURE_SET_NATURAL_MODE
     | FEATURE_SET_VERTICAL_OSCILLATION
+    | FEATURE_SET_VERTICAL_OSCILLATION_ANGLE
 )
 
 SERVICE_SET_BUZZER_ON = "fan_set_buzzer_on"
@@ -449,6 +452,7 @@ SERVICE_SET_ANION_OFF = "fan_set_anion_off"
 SERVICE_SET_VERTICAL_OSCILLATION_ON = "fan_set_vertical_oscillation_on"
 SERVICE_SET_VERTICAL_OSCILLATION_OFF = "fan_set_vertical_oscillation_off"
 SERVICE_TURN = "fan_turn"
+SERVICE_SET_VERTICAL_OSCILLATION_ANGLE = "fan_set_vertical_oscillation_angle"
 
 AIRPURIFIER_SERVICE_SCHEMA = vol.Schema({vol.Optional(ATTR_ENTITY_ID): cv.entity_ids})
 
@@ -470,6 +474,10 @@ SERVICE_SCHEMA_DELAY_OFF = AIRPURIFIER_SERVICE_SCHEMA.extend(
 
 SERVICE_SCHEMA_TURN = AIRPURIFIER_SERVICE_SCHEMA.extend(
     {vol.Required(ATTR_DIRECTION): vol.All(vol.Coerce(str), vol.In(["left", "right", "up", "down"]))}
+)
+
+SERVICE_SCHEMA_VERTICAL_OSCILLATION_ANGLE = AIRPURIFIER_SERVICE_SCHEMA.extend(
+    {vol.Required(ATTR_VERTICAL_ANGLE): cv.positive_int}
 )
 
 SERVICE_TO_METHOD = {
@@ -502,6 +510,10 @@ SERVICE_TO_METHOD = {
     SERVICE_TURN: {
         "method": "async_turn",
         "schema": SERVICE_SCHEMA_TURN,
+    },
+    SERVICE_SET_VERTICAL_OSCILLATION_ANGLE: {
+        "method": "async_set_vertical_oscillation_angle",
+        "schema": SERVICE_SCHEMA_VERTICAL_OSCILLATION_ANGLE,
     },
 }
 
@@ -1034,6 +1046,17 @@ class XiaomiFan(XiaomiGenericDevice):
 
         self._natural_mode = False
         await self.async_set_percentage(self._percentage)
+
+    async def async_set_vertical_oscillation_angle(self, vertical_angle: int) -> None:
+        """Set vertical oscillation angle."""
+        if self._device_features & FEATURE_SET_VERTICAL_OSCILLATION_ANGLE == 0:
+            return
+
+        await self._try_command(
+            "Setting vertical oscillation angle of the miio device failed.",
+            self._device.set_vertical_angle,
+            vertical_angle
+        )
 
 
 class XiaomiFanP5(XiaomiFan):
@@ -3098,6 +3121,15 @@ class FanP70(MiotDevice):
                 + ", ".join(str(i) for i in [30, 60, 90, 120])
             )
         return self.set_property("horizontal_swing_angle", angle)
+
+    def set_vertical_angle(self, angle: int):
+        """Set vertical oscillation angle."""
+        if angle not in [30, 60, 90, 100]:
+            raise FanException(
+                "Unsupported angle. Supported values: "
+                + ", ".join(str(i) for i in [30, 60, 90, 100])
+        )
+        return self.set_property("vertical_swing_angle", angle)
 
     def set_buzzer(self, buzzer: bool):
         """Set buzzer on/off."""

--- a/custom_components/xiaomi_miio_fan/services.yaml
+++ b/custom_components/xiaomi_miio_fan/services.yaml
@@ -157,3 +157,19 @@ fan_turn:
       name: Direction
       description: Supported values are left, right, up and down.
       example: left
+
+fan_set_vertical_oscillation_angle:
+  name: Set vertical oscillation angle
+  description: Set the vertical oscillation angle. (P70 and P76 only)
+  fields:
+    entity_id:
+      name: Entity ID
+      description: Name of the Xiaomi Mi Smart Fan entity.
+      selector:
+        entity:
+          integration: xiaomi_miio_fan
+          domain: fan
+    vertical_angle:
+      name: Vertical angle
+      description: Supported values are 30, 60, 90 or 100 degrees.
+      example: 30

--- a/custom_components/xiaomi_miio_fan/services.yaml
+++ b/custom_components/xiaomi_miio_fan/services.yaml
@@ -120,7 +120,7 @@ fan_set_delay_off:
 
 fan_set_vertical_oscillation_on:
   name: Set vertical oscillation on
-  description: Turn the vertical oscillation on. (P76 only)
+  description: Turn the vertical oscillation on. (P70 and P76 only)
   fields:
     entity_id:
       name: Entity ID
@@ -132,7 +132,7 @@ fan_set_vertical_oscillation_on:
 
 fan_set_vertical_oscillation_off:
   name: Set vertical oscillation off
-  description: Turn the vertical oscillation off. (P76 only)
+  description: Turn the vertical oscillation off. (P70 and P76 only)
   fields:
     entity_id:
       name: Entity ID

--- a/custom_components/xiaomi_miio_fan/strings.json
+++ b/custom_components/xiaomi_miio_fan/strings.json
@@ -115,6 +115,20 @@
           "description": "Supported values are left, right, up and down."
         }
       }
+    },
+    "fan_set_vertical_oscillation_angle": {
+      "name": "Set vertical oscillation angle",
+      "description": "Set the vertical oscillation angle. (P70 and P76 only)",
+      "fields": {
+        "entity_id": {
+          "name": "Entity ID",
+          "description": "Name of the Xiaomi Mi Smart Fan entity."
+        },
+        "vertical_angle": {
+          "name": "Vertical angle",
+          "description": "Supported values are 30, 60, 90 or 100 degrees."
+        }
+      }
     }
   }
 }

--- a/custom_components/xiaomi_miio_fan/strings.json
+++ b/custom_components/xiaomi_miio_fan/strings.json
@@ -102,6 +102,26 @@
         }
       }
     },
+    "fan_set_vertical_oscillation_on": {
+      "name": "Set vertical oscillation on",
+      "description": "Turn the vertical oscillation on. (P70 and P76 only)",
+      "fields": {
+        "entity_id": {
+          "name": "Entity ID",
+          "description": "Name of the Xiaomi Mi Smart Fan entity."
+        }
+      }
+    },
+    "fan_set_vertical_oscillation_off": {
+      "name": "Set vertical oscillation off",
+      "description": "Turn the vertical oscillation off. (P70 and P76 only)",
+      "fields": {
+        "entity_id": {
+          "name": "Entity ID",
+          "description": "Name of the Xiaomi Mi Smart Fan entity."
+        }
+      }
+    },
     "fan_turn": {
       "name": "Turn",
       "description": "Turn to the given direction. (P76 only)",


### PR DESCRIPTION
This PR adds the (missing?) service to set the vertical oscillation angle for Xiaomi P70 and P76 fans.

This was tested with my own Xiaomi P76. I don't have a P70 fan but it should work as well, the valid angles are the same according to the [user guide](https://www.mi.com/global/support/user-guide-pdf/om/xiaomi-smart-desktop-air-circulation-fan-/).