### PR TITLE
Implemented xiaomi.fan.2lite

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Credits: Thanks to [Rytilahti](https://github.com/rytilahti/python-miio) for all
 | Xiaomi Smart Tower Fan      | dmaker.fan.p39         | BPTS01DM | 22W, <=63dB |
 | Xiaomi Smart Standing Air Circulation Fan | xiaomi.fan.p76 | JLLDS01XY | - |
 | Xiaomi Smart Desktop Air Circulation Fan  | xiaomi.fan.p70 | - | - |
+| Mi Smart Standing Fan 2 Lite              | xiaomi.fan.2lite | - | - |
 
 
 ## Features

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -3477,7 +3477,7 @@ class Fan2Lite(MiotDevice):
 
     def set_buzzer(self, buzzer: bool):
         """Set buzzer on/off."""
-        return self.set_property("buzzer", bool(buzzer))
+        return self.set_property("buzzer", buzzer)
 
     def set_child_lock(self, lock: bool):
         """Set child lock on/off."""

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -66,6 +66,7 @@ MODEL_FAN_P33 = "dmaker.fan.p33"  # Mi Smart Standing Fan Pro 2
 MODEL_FAN_P39 = "dmaker.fan.p39"  # Smart Tower Fan
 MODEL_FAN_P76 = "xiaomi.fan.p76"  # Xiaomi Smart Standing Air Circulation Fan
 MODEL_FAN_P70 = "xiaomi.fan.p70"  # Smart Desktop Air Circulation Fan
+MODEL_FAN_2LITE = "xiaomi.fan.2lite"  # Mi Smart Standing Fan 2 Lite
 MODEL_FAN_LESHOW_SS4 = "leshow.fan.ss4"
 MODEL_FAN_1C = "dmaker.fan.1c"  # Pedestal Fan Fan 1C
 
@@ -95,6 +96,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
                 MODEL_FAN_P39,
                 MODEL_FAN_P76,
                 MODEL_FAN_P70,
+                MODEL_FAN_2LITE,
                 MODEL_FAN_LESHOW_SS4,
                 MODEL_FAN_1C,
             ]
@@ -217,6 +219,15 @@ AVAILABLE_ATTRIBUTES_FAN_P70 = {
     ATTR_BUZZER: "buzzer",
     ATTR_CHILD_LOCK: "child_lock",
     ATTR_RAW_SPEED: "fan_speed",
+}
+
+AVAILABLE_ATTRIBUTES_FAN_2LITE = {
+    ATTR_MODE: "mode",
+    ATTR_OSCILLATE: "horizontal_swing",
+    ATTR_DELAY_OFF_COUNTDOWN: "delay_time",
+    ATTR_LED: "led",
+    ATTR_BUZZER: "buzzer",
+    ATTR_CHILD_LOCK: "child_lock",
 }
 
 AVAILABLE_ATTRIBUTES_FAN_LESHOW_SS4 = {
@@ -363,6 +374,12 @@ FAN_PRESET_MODES_P70 = {
 
 FAN_SPEEDS_P70 = [FAN_SPEED_LEVEL1, FAN_SPEED_LEVEL2, FAN_SPEED_LEVEL3, FAN_SPEED_LEVEL4]
 
+FAN_PRESET_MODE_SLEEP = "Sleep"
+
+FAN_PRESET_MODES_2LITE = [FAN_PRESET_MODE_SLEEP]
+
+FAN_2LITE_SPEED_COUNT = 3
+
 SUCCESS = ["ok"]
 
 FEATURE_SET_BUZZER = 1
@@ -435,6 +452,13 @@ FEATURE_FLAGS_FAN_P70 = (
     | FEATURE_SET_NATURAL_MODE
     | FEATURE_SET_VERTICAL_OSCILLATION
     | FEATURE_SET_VERTICAL_OSCILLATION_ANGLE
+)
+
+FEATURE_FLAGS_FAN_2LITE = (
+    FEATURE_SET_BUZZER
+    | FEATURE_SET_CHILD_LOCK
+    | FEATURE_SET_LED
+    | FEATURE_SET_NATURAL_MODE
 )
 
 SERVICE_SET_BUZZER_ON = "fan_set_buzzer_on"
@@ -618,6 +642,11 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     elif model == MODEL_FAN_P70:
         fan = FanP70(host, token, model=model)
         device = XiaomiFanP70(
+            name, fan, model, unique_id, retries, preset_modes_override
+        )
+    elif model == MODEL_FAN_2LITE:
+        fan = Fan2Lite(host, token, model=model)
+        device = XiaomiFan2Lite(
             name, fan, model, unique_id, retries, preset_modes_override
         )
     else:
@@ -3325,4 +3354,297 @@ class XiaomiFanP70(XiaomiFanP33):
             "Setting vertical oscillation off of the miio device failed.",
             self._device.set_vertical_oscillate,
             False,
+        )
+
+
+class OperationModeFan2Lite(Enum):
+    Straight = 0
+    Natural = 1
+
+
+class FanStatus2Lite(DeviceStatus):
+    """Container for status reports for Fan2Lite."""
+
+    def __init__(self, data: Dict[str, Any]) -> None:
+        self.data = data
+
+    @property
+    def power(self) -> bool:
+        return self.data["power"]
+
+    @property
+    def fault(self) -> int:
+        return self.data["fault"]
+
+    @property
+    def mode(self) -> str:
+        return OperationModeFan2Lite(self.data["mode"]).name
+
+    @property
+    def fan_level(self) -> int:
+        return self.data["fan_level"]
+
+    @property
+    def horizontal_swing(self) -> bool:
+        return self.data["horizontal_swing"]
+
+    @property
+    def led(self) -> bool:
+        return self.data["led"]
+
+    @property
+    def buzzer(self) -> bool:
+        return self.data["buzzer"]
+
+    @property
+    def child_lock(self) -> bool:
+        return self.data["child_lock"]
+
+    @property
+    def delay_time(self) -> int:
+        return self.data["delay_time"]
+
+
+class Fan2Lite(MiotDevice):
+    """Main class representing the Mi Smart Standing Fan 2 Lite (xiaomi.fan.2lite)."""
+
+    mapping = {
+        # urn:miot-spec-v2:device:fan:0000A005:xiaomi-2lite:1
+        "power":            {"siid": 2, "piid": 1},
+        "fault":            {"siid": 2, "piid": 2},
+        "mode":             {"siid": 2, "piid": 3},
+        "fan_level":        {"siid": 2, "piid": 4},
+        "horizontal_swing": {"siid": 2, "piid": 6},
+        "led":              {"siid": 5, "piid": 1},
+        "buzzer":           {"siid": 7, "piid": 1},
+        "child_lock":       {"siid": 8, "piid": 1},
+        "delay":            {"siid": 9, "piid": 1},
+        "delay_time":       {"siid": 9, "piid": 2},
+    }
+
+    def __init__(
+        self,
+        ip: str = None,
+        token: str = None,
+        start_id: int = 0,
+        debug: int = 0,
+        lazy_discover: bool = True,
+        timeout: int = 5,
+        model: str = MODEL_FAN_2LITE,
+    ) -> None:
+        super().__init__(ip, token, start_id, debug, lazy_discover, timeout, model=model)
+
+    def get_properties_for_mapping(self, *, max_properties=15) -> list:
+        """Retrieve raw properties based on mapping."""
+        mapping = self._get_mapping()
+
+        properties = [
+            {"did": k, **_filter_request_fields(v)}
+            for k, v in mapping.items()
+            if "aiid" not in v and ("access" not in v or "read" in v["access"])
+        ]
+
+        return self.get_properties(
+            properties, property_getter="get_properties", max_properties=max_properties
+        )
+
+    def status(self):
+        """Retrieve properties."""
+        return FanStatus2Lite(
+            {
+                prop["did"]: prop["value"] if prop["code"] == 0 else None
+                for prop in self.get_properties_for_mapping()
+            }
+        )
+
+    def on(self):
+        """Power on."""
+        return self.set_property("power", True)
+
+    def off(self):
+        """Power off."""
+        return self.set_property("power", False)
+
+    def set_fan_level(self, level: int):
+        """Set fan level (0-2)."""
+        if level not in [0, 1, 2]:
+            raise FanException("Invalid fan level: %s" % level)
+        return self.set_property("fan_level", level)
+
+    def set_oscillate(self, oscillate: bool):
+        """Set horizontal oscillation on/off."""
+        return self.set_property("horizontal_swing", oscillate)
+
+    def set_buzzer(self, buzzer: bool):
+        """Set buzzer on/off."""
+        return self.set_property("buzzer", bool(buzzer))
+
+    def set_child_lock(self, lock: bool):
+        """Set child lock on/off."""
+        return self.set_property("child_lock", lock)
+
+    def set_light(self, light: bool):
+        """Set indicator state."""
+        return self.set_property("led", light)
+
+    def set_mode(self, mode: OperationModeFan2Lite):
+        """Set mode."""
+        return self.set_property("mode", mode.value)
+
+    def delay_off(self, minutes: int):
+        """Set delay off in minutes (0-480). 0 deactivates the timer."""
+        if minutes < 0 or minutes > 480:
+            raise FanException("Invalid value for a delayed turn off: %s" % minutes)
+        if minutes == 0:
+            return self.set_property("delay", False)
+        self.set_property("delay_time", minutes)
+        return self.set_property("delay", True)
+
+
+class XiaomiFan2Lite(XiaomiFanP33):
+    """Representation of a Mi Smart Standing Fan 2 Lite (xiaomi.fan.2lite)."""
+
+    def __init__(self, name, device, model, unique_id, retries, preset_modes_override):
+        super().__init__(name, device, model, unique_id, retries, preset_modes_override)
+
+        self._device_features = FEATURE_FLAGS_FAN_2LITE
+        self._available_attributes = AVAILABLE_ATTRIBUTES_FAN_2LITE
+        self._percentage = None
+        self._preset_modes = list(FAN_PRESET_MODES_2LITE)
+        if preset_modes_override is not None:
+            self._preset_modes = preset_modes_override
+
+        self._preset_mode = None
+        self._oscillate = None
+        self._natural_mode = False
+
+        self._state_attrs = {
+            ATTR_MODEL: self._model,
+            **{attribute: None for attribute in self._available_attributes},
+        }
+
+    @property
+    def supported_features(self) -> int:
+        return (
+            FanEntityFeature.OSCILLATE
+            | FanEntityFeature.PRESET_MODE
+            | FanEntityFeature.SET_SPEED
+            | FanEntityFeature.TURN_OFF
+            | FanEntityFeature.TURN_ON
+        )
+
+    @property
+    def speed_count(self) -> int:
+        return FAN_2LITE_SPEED_COUNT
+
+    async def async_update(self):
+        if self._skip_update:
+            self._skip_update = False
+            return
+
+        try:
+            state = await self.hass.async_add_executor_job(self._device.status)
+            _LOGGER.debug("Got new state: %s", state)
+
+            self._available = True
+            self._oscillate = state.horizontal_swing
+            self._natural_mode = state.mode == OperationModeFan2Lite.Natural.name
+            self._state = state.power
+            self._preset_mode = FAN_PRESET_MODE_SLEEP if self._natural_mode else None
+
+            if state.fan_level is None:
+                self._percentage = None
+            else:
+                self._percentage = int(
+                    round((state.fan_level + 1) * 100 / FAN_2LITE_SPEED_COUNT)
+                )
+
+            self._state_attrs.update(
+                {
+                    key: self._extract_value_from_attribute(state, value)
+                    for key, value in self._available_attributes.items()
+                    if hasattr(state, value)
+                }
+            )
+            self._retry = 0
+
+        except DeviceException as ex:
+            self._retry = self._retry + 1
+            if self._retry < self._retries:
+                _LOGGER.info(
+                    "%s Got exception while fetching the state: %s , _retry=%s",
+                    self.__class__.__name__,
+                    ex,
+                    self._retry,
+                )
+            else:
+                self._available = False
+                _LOGGER.error(
+                    "%s Got exception while fetching the state: %s , _retry=%s",
+                    self.__class__.__name__,
+                    ex,
+                    self._retry,
+                )
+
+    async def async_set_percentage(self, percentage: int) -> None:
+        _LOGGER.debug("Setting the fan percentage to: %s", percentage)
+
+        if percentage == 0:
+            await self.async_turn_off()
+            return
+
+        level = max(0, min(FAN_2LITE_SPEED_COUNT - 1,
+                           int((percentage - 1) * FAN_2LITE_SPEED_COUNT / 100)))
+
+        if not self._state:
+            await self._try_command(
+                "Turning the miio device on failed.", self._device.on
+            )
+        if self._natural_mode:
+            await self._try_command(
+                "Setting fan mode of the miio device failed.",
+                self._device.set_mode,
+                OperationModeFan2Lite.Straight,
+            )
+        await self._try_command(
+            "Setting fan level of the miio device failed.",
+            self._device.set_fan_level,
+            level,
+        )
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        _LOGGER.debug("Setting the preset mode to: %s", preset_mode)
+
+        if not self._state:
+            await self._try_command(
+                "Turning the miio device on failed.", self._device.on
+            )
+
+        mode = (
+            OperationModeFan2Lite.Natural
+            if preset_mode == FAN_PRESET_MODE_SLEEP
+            else OperationModeFan2Lite.Straight
+        )
+        await self._try_command(
+            "Setting fan mode of the miio device failed.",
+            self._device.set_mode,
+            mode,
+        )
+
+    async def async_set_natural_mode_on(self):
+        if self._device_features & FEATURE_SET_NATURAL_MODE == 0:
+            return
+        await self._try_command(
+            "Setting fan natural mode of the miio device failed.",
+            self._device.set_mode,
+            OperationModeFan2Lite.Natural,
+        )
+
+    async def async_set_natural_mode_off(self):
+        if self._device_features & FEATURE_SET_NATURAL_MODE == 0:
+            return
+        await self._try_command(
+            "Setting fan natural mode of the miio device failed.",
+            self._device.set_mode,
+            OperationModeFan2Lite.Straight,
         )

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -7,6 +7,7 @@ https://home-assistant.io/components/fan.xiaomi_miio/
 
 import asyncio
 import logging
+import math
 from enum import Enum
 from functools import partial
 from typing import Any, Dict, Optional
@@ -25,6 +26,8 @@ from homeassistant.exceptions import PlatformNotReady
 from homeassistant.util.percentage import (
     ordered_list_item_to_percentage,
     percentage_to_ordered_list_item,
+    percentage_to_ranged_value,
+    ranged_value_to_percentage,
 )
 from miio import Device, DeviceException, Fan, Fan1C, FanLeshow, FanMiot, FanP5
 from miio.fan_common import FanException
@@ -3467,7 +3470,7 @@ class Fan2Lite(MiotDevice):
 
     def set_fan_level(self, level: int):
         """Set fan level (0-2)."""
-        if level not in [0, 1, 2]:
+        if level not in range(FAN_2LITE_SPEED_COUNT):
             raise FanException("Invalid fan level: %s" % level)
         return self.set_property("fan_level", level)
 
@@ -3555,8 +3558,8 @@ class XiaomiFan2Lite(XiaomiFanP33):
             if state.fan_level is None:
                 self._percentage = None
             else:
-                self._percentage = int(
-                    round((state.fan_level + 1) * 100 / FAN_2LITE_SPEED_COUNT)
+                self._percentage = ranged_value_to_percentage(
+                    (1, FAN_2LITE_SPEED_COUNT), state.fan_level + 1
                 )
 
             self._state_attrs.update(
@@ -3593,8 +3596,10 @@ class XiaomiFan2Lite(XiaomiFanP33):
             await self.async_turn_off()
             return
 
-        level = max(0, min(FAN_2LITE_SPEED_COUNT - 1,
-                           int((percentage - 1) * FAN_2LITE_SPEED_COUNT / 100)))
+        level = (
+            math.ceil(percentage_to_ranged_value((1, FAN_2LITE_SPEED_COUNT), percentage))
+            - 1
+        )
 
         if not self._state:
             await self._try_command(


### PR DESCRIPTION
Adds support for the Mi Smart Standing Fan 2 Lite (`xiaomi.fan.2lite`), requested in #307.

  The MIoT spec for this model is pretty stripped down compared to the P70/P76 — no continuous fan speed, no swing angle, no vertical swing, just three fan levels and a Direct/Sleep mode toggle. So instead of
  mirroring the P70 layout 1:1, I wired it up like this:

  - **Percentage slider** controls the fan level (3 steps, snapping to 33% / 67% / 100%).
  - **Single `Sleep` preset** flips the device into Natural mode. 
  - Horizontal oscillation, buzzer, child lock, LED and delay-off are all exposed the usual way.