### PR TITLE
Add xiaomi.fan.p45

### DIFF
--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -3190,6 +3190,15 @@ class XiaomiFanP45(XiaomiFanMiot):
             OperationModeFanP45.Straight,
         )
 
+    async def async_turn(self, direction: str):
+        if self._device_features & FEATURE_TURN == 0:
+            return
+        await self._try_command(
+            "Turning the miio device failed.",
+            self._device.turn,
+            direction,
+        )
+
 
 class OperationModeFanP76(Enum):
     """Operation mode enum for FanP76."""

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -2993,7 +2993,6 @@ class FanP45(MiotDevice):
         return self.set_property("mode", OperationModeFanP45[mode.name].value)
 
     def set_child_lock(self, lock: bool):
-        self.status()
         return self.set_property("child_lock", bool(lock))
 
     def set_buzzer(self, buzzer: bool):

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -3075,6 +3075,7 @@ class XiaomiFanP45(XiaomiFanMiot):
             if state.mode == OperationModeFanP45.Sleep.name:
                 self._preset_mode = FAN_PRESET_MODE_SLEEP
             else:
+                self._preset_mode = None
                 for preset_mode, value in FAN_PRESET_MODES_P45.items():
                     if preset_mode in (SPEED_OFF, FAN_PRESET_MODE_SLEEP):
                         continue

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -2831,14 +2831,17 @@ class FanStatusP45(DeviceStatus):
     """Container for status reports for FanP45 (Xiaomi Smart Tower Fan 2)."""
 
     def __init__(self, data):
+        """Initialize."""
         self.data = data
 
     @property
     def power(self) -> bool:
+        """Return the power state."""
         return self.data["power"]
 
     @property
     def fault(self) -> int:
+        """Return the fault code."""
         return self.data["fault"]
 
     @property
@@ -2853,30 +2856,37 @@ class FanStatusP45(DeviceStatus):
 
     @property
     def mode(self) -> str:
+        """Return the operation mode."""
         return OperationModeFanP45(self.data["mode"]).name
 
     @property
     def horizontal_swing(self) -> bool:
+        """Return the horizontal swing state."""
         return self.data["horizontal_swing"]
 
     @property
     def horizontal_swing_angle(self) -> int:
+        """Return the horizontal swing angle."""
         return self.data["horizontal_swing_angle"]
 
     @property
     def child_lock(self) -> bool:
+        """Return the child lock state."""
         return self.data["child_lock"]
 
     @property
     def led(self) -> bool:
+        """Return the LED state."""
         return self.data["led"]
 
     @property
     def buzzer(self) -> bool:
+        """Return the buzzer state."""
         return self.data["buzzer"]
 
     @property
     def delay(self) -> bool:
+        """Return the delay state."""
         return self.data["delay"]
 
     @property
@@ -2933,7 +2943,10 @@ class FanP45(MiotDevice):
         timeout=5,
         model=MODEL_FAN_P45,
     ):
-        super().__init__(ip, token, start_id, debug, lazy_discover, timeout, model=model)
+        """Initialize."""
+        super().__init__(
+            ip, token, start_id, debug, lazy_discover, timeout, model=model
+        )
 
     def get_properties_for_mapping(self, *, max_properties=15):
         """Retrieve raw properties, skipping action-only entries."""
@@ -2948,6 +2961,7 @@ class FanP45(MiotDevice):
         )
 
     def status(self):
+        """Retrieve properties."""
         return FanStatusP45(
             {
                 prop["did"]: prop["value"] if prop["code"] == 0 else None
@@ -2956,24 +2970,27 @@ class FanP45(MiotDevice):
         )
 
     def on(self):
+        """Power on."""
         return self.set_property("power", True)
 
     def off(self):
+        """Power off."""
         return self.set_property("power", False)
 
     def set_speed(self, speed: int):
         """Set fan speed percentage (1..100)."""
         if speed < 1 or speed > 100:
-            raise FanException("Invalid speed: %s" % speed)
+            raise FanException(f"Invalid speed: {speed}")
         return self.set_property("fan_speed", speed)
 
     def set_fan_level(self, fan_level: int):
         """Set preset fan level (1..4)."""
         if fan_level < 1 or fan_level > 4:
-            raise FanException("Invalid fan level: %s" % fan_level)
+            raise FanException(f"Invalid fan level: {fan_level}")
         return self.set_property("fan_level", fan_level)
 
     def set_oscillate(self, oscillate: bool):
+        """Set horizontal oscillation on/off."""
         return self.set_property("horizontal_swing", bool(oscillate))
 
     def set_angle(self, angle: int):
@@ -2990,21 +3007,25 @@ class FanP45(MiotDevice):
         return self.set_property("horizontal_swing_angle", angle)
 
     def set_mode(self, mode: OperationModeFanP45):
+        """Set mode."""
         return self.set_property("mode", OperationModeFanP45[mode.name].value)
 
     def set_child_lock(self, lock: bool):
+        """Set child lock on/off."""
         return self.set_property("child_lock", bool(lock))
 
     def set_buzzer(self, buzzer: bool):
+        """Set buzzer on/off."""
         return self.set_property("buzzer", bool(buzzer))
 
     def set_light(self, light: bool):
+        """Set indicator state."""
         return self.set_property("led", bool(light))
 
     def delay_off(self, minutes: int):
         """Set delayed turn-off in minutes (0..480; 0 disables)."""
         if minutes < 0 or minutes > 480:
-            raise FanException("Invalid value for a delayed turn off: %s" % minutes)
+            raise FanException(f"Invalid value for a delayed turn off: {minutes}")
         # Toggle the delay enable flag in sync with the time value.
         if minutes == 0:
             self.set_property("delay", False)
@@ -3020,7 +3041,8 @@ class FanP45(MiotDevice):
             return self.call_action("turn_right")
         else:
             raise FanException(
-                "Unsupported direction. Supported values: " + ", ".join(["left", "right"])
+                "Unsupported direction. Supported values: "
+                + ", ".join(["left", "right"])
             )
 
 
@@ -3028,6 +3050,7 @@ class XiaomiFanP45(XiaomiFanMiot):
     """Representation of the Xiaomi Smart Tower Fan 2 (xiaomi.fan.p45)."""
 
     def __init__(self, name, device, model, unique_id, retries, preset_modes_override):
+        """Initialize the fan entity."""
         super().__init__(name, device, model, unique_id, retries, preset_modes_override)
 
         self._device_features = FEATURE_FLAGS_FAN_P45
@@ -3048,6 +3071,7 @@ class XiaomiFanP45(XiaomiFanMiot):
 
     @property
     def supported_features(self) -> int:
+        """Return supported features."""
         return (
             FanEntityFeature.OSCILLATE
             | FanEntityFeature.PRESET_MODE
@@ -3057,6 +3081,7 @@ class XiaomiFanP45(XiaomiFanMiot):
         )
 
     async def async_update(self):
+        """Fetch state from the device."""
         if self._skip_update:
             self._skip_update = False
             return
@@ -3112,21 +3137,26 @@ class XiaomiFanP45(XiaomiFanMiot):
 
     @property
     def percentage(self):
+        """Return the current percentage."""
         return self._percentage
 
     @property
     def preset_modes(self):
+        """Return the list of available preset modes."""
         return self._preset_modes
 
     @property
     def preset_mode(self):
+        """Return the current preset mode."""
         if self._state:
             return self._preset_mode
         return None
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
-        """Set preset mode — combines level (1..4) with Straight/Natural mode,
-        or selects standalone Sleep mode."""
+        """Set preset mode.
+
+        Combines level (1..4) with Straight/Natural mode, or selects standalone Sleep mode.
+        """
         _LOGGER.debug("Setting the preset mode to: %s", preset_mode)
 
         if preset_mode == SPEED_OFF:
@@ -3134,7 +3164,9 @@ class XiaomiFanP45(XiaomiFanMiot):
             return
 
         if not self._state:
-            await self._try_command("Turning the miio device on failed.", self._device.on)
+            await self._try_command(
+                "Turning the miio device on failed.", self._device.on
+            )
 
         if preset_mode == FAN_PRESET_MODE_SLEEP:
             await self._try_command(
@@ -3157,6 +3189,7 @@ class XiaomiFanP45(XiaomiFanMiot):
         )
 
     async def async_set_percentage(self, percentage: int) -> None:
+        """Set the speed percentage of the fan."""
         _LOGGER.debug("Setting the fan speed percentage to: %s", percentage)
 
         if percentage == 0:
@@ -3164,7 +3197,9 @@ class XiaomiFanP45(XiaomiFanMiot):
             return
 
         if not self._state:
-            await self._try_command("Turning the miio device on failed.", self._device.on)
+            await self._try_command(
+                "Turning the miio device on failed.", self._device.on
+            )
 
         await self._try_command(
             "Setting fan speed percentage of the miio device failed.",
@@ -3173,6 +3208,7 @@ class XiaomiFanP45(XiaomiFanMiot):
         )
 
     async def async_set_natural_mode_on(self):
+        """Turn the natural mode on."""
         if self._device_features & FEATURE_SET_NATURAL_MODE == 0:
             return
         await self._try_command(
@@ -3182,6 +3218,7 @@ class XiaomiFanP45(XiaomiFanMiot):
         )
 
     async def async_set_natural_mode_off(self):
+        """Turn the natural mode off."""
         if self._device_features & FEATURE_SET_NATURAL_MODE == 0:
             return
         await self._try_command(
@@ -3191,6 +3228,7 @@ class XiaomiFanP45(XiaomiFanMiot):
         )
 
     async def async_turn(self, direction: str):
+        """Turn fan in the given direction."""
         if self._device_features & FEATURE_TURN == 0:
             return
         await self._try_command(

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -66,6 +66,7 @@ MODEL_FAN_P18 = "dmaker.fan.p18"  # Mi Smart Standing Fan 2 P18
 MODEL_FAN_P30 = "dmaker.fan.p30"  # Mi Smart Standing Fan 2 P30
 MODEL_FAN_P33 = "dmaker.fan.p33"  # Mi Smart Standing Fan Pro 2
 MODEL_FAN_P39 = "dmaker.fan.p39"  # Smart Tower Fan
+MODEL_FAN_P45 = "xiaomi.fan.p45"  # Xiaomi Smart Tower Fan 2 (BHR8846EU)
 MODEL_FAN_XIAOMI_P30 = "xiaomi.fan.p30"  # Mi/Xiaomi Smart Standing Fan 2 P30
 MODEL_FAN_P76 = "xiaomi.fan.p76"  # Xiaomi Smart Standing Air Circulation Fan
 MODEL_FAN_P70 = "xiaomi.fan.p70"  # Smart Desktop Air Circulation Fan
@@ -99,6 +100,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
                 MODEL_FAN_XIAOMI_P30,
                 MODEL_FAN_P33,
                 MODEL_FAN_P39,
+                MODEL_FAN_P45,
                 MODEL_FAN_P76,
                 MODEL_FAN_P70,
                 MODEL_FAN_P85,
@@ -199,6 +201,17 @@ AVAILABLE_ATTRIBUTES_FAN_P39 = {
     ATTR_DELAY_OFF_COUNTDOWN: "delay_off_countdown",
     ATTR_CHILD_LOCK: "child_lock",
     ATTR_RAW_SPEED: "speed",
+}
+
+AVAILABLE_ATTRIBUTES_FAN_P45 = {
+    ATTR_MODE: "mode",
+    ATTR_OSCILLATE: "horizontal_swing",
+    ATTR_ANGLE: "horizontal_swing_angle",
+    ATTR_DELAY_OFF_COUNTDOWN: "delay_time",
+    ATTR_LED: "led",
+    ATTR_BUZZER: "buzzer",
+    ATTR_CHILD_LOCK: "child_lock",
+    ATTR_RAW_SPEED: "fan_speed",
 }
 
 AVAILABLE_ATTRIBUTES_FAN_XIAOMI_P30 = {
@@ -442,6 +455,34 @@ FAN_PRESET_MODES_P85 = {
 
 FAN_PRESET_MODE_SLEEP = "Sleep"
 
+# Smart Tower Fan 2 (xiaomi.fan.p45) — fan-level enum: Level1..Level4 (1..4).
+# Sleep is a standalone mode (no level selector) and is treated as a single
+# preset that maps to mode=Sleep.
+FAN_PRESET_MODES_P45 = {
+    SPEED_OFF: -1,
+    FAN_SPEED_LEVEL1: 1,
+    FAN_SPEED_LEVEL2: 2,
+    FAN_SPEED_LEVEL3: 3,
+    FAN_SPEED_LEVEL4: 4,
+    FAN_SPEED_NATURAL1: 1,
+    FAN_SPEED_NATURAL2: 2,
+    FAN_SPEED_NATURAL3: 3,
+    FAN_SPEED_NATURAL4: 4,
+    FAN_PRESET_MODE_SLEEP: 1,
+}
+
+FAN_SPEEDS_P45 = [
+    FAN_SPEED_LEVEL1,
+    FAN_SPEED_LEVEL2,
+    FAN_SPEED_LEVEL3,
+    FAN_SPEED_LEVEL4,
+    FAN_SPEED_NATURAL1,
+    FAN_SPEED_NATURAL2,
+    FAN_SPEED_NATURAL3,
+    FAN_SPEED_NATURAL4,
+    FAN_PRESET_MODE_SLEEP,
+]
+
 FAN_PRESET_MODES_2LITE = [FAN_PRESET_MODE_SLEEP]
 
 FAN_2LITE_SPEED_COUNT = 3
@@ -497,6 +538,17 @@ FEATURE_FLAGS_FAN_P33 = (
 
 FEATURE_FLAGS_FAN_P39 = (
     FEATURE_SET_CHILD_LOCK | FEATURE_SET_OSCILLATION_ANGLE | FEATURE_SET_NATURAL_MODE
+)
+
+# Xiaomi Smart Tower Fan 2 (xiaomi.fan.p45). Canonical spec exposes
+# 30/60/90/120/150 swing angles and three modes (Straight / Natural / Sleep).
+FEATURE_FLAGS_FAN_P45 = (
+    FEATURE_SET_BUZZER
+    | FEATURE_SET_CHILD_LOCK
+    | FEATURE_SET_LED
+    | FEATURE_SET_OSCILLATION_ANGLE
+    | FEATURE_SET_NATURAL_MODE
+    | FEATURE_TURN
 )
 
 FEATURE_FLAGS_FAN_XIAOMI_P30 = (
@@ -734,6 +786,11 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     elif model == MODEL_FAN_P39:
         fan = FanP39(host, token, model=model)
         device = XiaomiFanP39(
+            name, fan, model, unique_id, retries, preset_modes_override
+        )
+    elif model == MODEL_FAN_P45:
+        fan = FanP45(host, token, model=model)
+        device = XiaomiFanP45(
             name, fan, model, unique_id, retries, preset_modes_override
         )
     elif model == MODEL_FAN_P76:
@@ -2760,6 +2817,378 @@ class FanP39(MiotDevice):
         elif direction == FanMoveDirection.Right:
             value = 2
         return self.set_property("set_move", value)
+
+
+class OperationModeFanP45(Enum):
+    """Operating modes for the Xiaomi Smart Tower Fan 2 (xiaomi.fan.p45)."""
+
+    Straight = 0
+    Natural = 1
+    Sleep = 2
+
+
+class FanStatusP45(DeviceStatus):
+    """Container for status reports for FanP45 (Xiaomi Smart Tower Fan 2)."""
+
+    def __init__(self, data):
+        self.data = data
+
+    @property
+    def power(self) -> bool:
+        return self.data["power"]
+
+    @property
+    def fault(self) -> int:
+        return self.data["fault"]
+
+    @property
+    def fan_level(self) -> int:
+        """4-step preset level (1..4)."""
+        return self.data["fan_level"]
+
+    @property
+    def fan_speed(self) -> int:
+        """Fine-grained fan speed percentage (1..100)."""
+        return self.data["fan_speed"]
+
+    @property
+    def mode(self) -> str:
+        return OperationModeFanP45(self.data["mode"]).name
+
+    @property
+    def horizontal_swing(self) -> bool:
+        return self.data["horizontal_swing"]
+
+    @property
+    def horizontal_swing_angle(self) -> int:
+        return self.data["horizontal_swing_angle"]
+
+    @property
+    def child_lock(self) -> bool:
+        return self.data["child_lock"]
+
+    @property
+    def led(self) -> bool:
+        return self.data["led"]
+
+    @property
+    def buzzer(self) -> bool:
+        return self.data["buzzer"]
+
+    @property
+    def delay(self) -> bool:
+        return self.data["delay"]
+
+    @property
+    def delay_time(self) -> int:
+        """Configured off-delay in minutes (0..480)."""
+        return self.data["delay_time"]
+
+    @property
+    def delay_remain_time(self) -> int:
+        """Remaining off-delay countdown in seconds."""
+        return self.data["delay_remain_time"]
+
+
+class FanP45(MiotDevice):
+    """Xiaomi Smart Tower Fan 2 (xiaomi.fan.p45, BHR8846EU).
+
+    Implemented against the canonical xiaomi.fan.p45 MIoT spec instance
+    urn:miot-spec-v2:device:fan:0000A005:xiaomi-p45:1:0000D062 (the bare
+    ``:1`` URN is not registered on miot-spec.org; only the full instance
+    with the ``:0000D062`` suffix resolves). The CN counterpart reports as
+    dmaker.fan.p45 and uses a different profile, so this class is
+    intentionally only registered for the xiaomi.fan.p45 model string.
+
+    The spec exposes all five horizontal swing angles (30/60/90/120/150)
+    and three modes (Straight / Natural / Sleep).
+    """
+
+    mapping = {
+        # urn:miot-spec-v2:device:fan:0000A005:xiaomi-p45:1:0000D062
+        "power": {"siid": 2, "piid": 1},
+        "fault": {"siid": 2, "piid": 2, "access": ["read"]},
+        "mode": {"siid": 2, "piid": 3},
+        "fan_level": {"siid": 2, "piid": 4},
+        "fan_speed": {"siid": 2, "piid": 5},
+        "horizontal_swing": {"siid": 2, "piid": 6},
+        "horizontal_swing_angle": {"siid": 2, "piid": 7},
+        "led": {"siid": 5, "piid": 1},
+        "buzzer": {"siid": 7, "piid": 1},
+        "child_lock": {"siid": 11, "piid": 1},
+        "delay": {"siid": 12, "piid": 1},
+        "delay_time": {"siid": 12, "piid": 2},
+        "delay_remain_time": {"siid": 12, "piid": 3},
+        "turn_left": {"siid": 2, "aiid": 4},
+        "turn_right": {"siid": 2, "aiid": 5},
+    }
+
+    def __init__(
+        self,
+        ip=None,
+        token=None,
+        start_id=0,
+        debug=0,
+        lazy_discover=True,
+        timeout=5,
+        model=MODEL_FAN_P45,
+    ):
+        super().__init__(ip, token, start_id, debug, lazy_discover, timeout, model=model)
+
+    def get_properties_for_mapping(self, *, max_properties=15):
+        """Retrieve raw properties, skipping action-only entries."""
+        mapping = self._get_mapping()
+        properties = [
+            {"did": k, **_filter_request_fields(v)}
+            for k, v in mapping.items()
+            if "aiid" not in v and ("access" not in v or "read" in v["access"])
+        ]
+        return self.get_properties(
+            properties, property_getter="get_properties", max_properties=max_properties
+        )
+
+    def status(self):
+        return FanStatusP45(
+            {
+                prop["did"]: prop["value"] if prop["code"] == 0 else None
+                for prop in self.get_properties_for_mapping()
+            }
+        )
+
+    def on(self):
+        return self.set_property("power", True)
+
+    def off(self):
+        return self.set_property("power", False)
+
+    def set_speed(self, speed: int):
+        """Set fan speed percentage (1..100)."""
+        if speed < 1 or speed > 100:
+            raise FanException("Invalid speed: %s" % speed)
+        return self.set_property("fan_speed", speed)
+
+    def set_fan_level(self, fan_level: int):
+        """Set preset fan level (1..4)."""
+        if fan_level < 1 or fan_level > 4:
+            raise FanException("Invalid fan level: %s" % fan_level)
+        return self.set_property("fan_level", fan_level)
+
+    def set_oscillate(self, oscillate: bool):
+        return self.set_property("horizontal_swing", bool(oscillate))
+
+    def set_angle(self, angle: int):
+        """Set horizontal oscillation included angle.
+
+        Canonical xiaomi.fan.p45 spec exposes 30/60/90/120/150 degrees.
+        Region-locked firmware may reject some values at runtime.
+        """
+        if angle not in [30, 60, 90, 120, 150]:
+            raise FanException(
+                "Unsupported angle. Supported values: "
+                + ", ".join(str(i) for i in [30, 60, 90, 120, 150])
+            )
+        return self.set_property("horizontal_swing_angle", angle)
+
+    def set_mode(self, mode: OperationModeFanP45):
+        return self.set_property("mode", OperationModeFanP45[mode.name].value)
+
+    def set_child_lock(self, lock: bool):
+        self.status()
+        return self.set_property("child_lock", bool(lock))
+
+    def set_buzzer(self, buzzer: bool):
+        return self.set_property("buzzer", bool(buzzer))
+
+    def set_light(self, light: bool):
+        return self.set_property("led", bool(light))
+
+    def delay_off(self, minutes: int):
+        """Set delayed turn-off in minutes (0..480; 0 disables)."""
+        if minutes < 0 or minutes > 480:
+            raise FanException("Invalid value for a delayed turn off: %s" % minutes)
+        # Toggle the delay enable flag in sync with the time value.
+        if minutes == 0:
+            self.set_property("delay", False)
+        else:
+            self.set_property("delay", True)
+        return self.set_property("delay_time", minutes)
+
+    def turn(self, direction: str):
+        """Step the fan 7.5 degrees to the given direction (action call)."""
+        if direction == "left":
+            return self.call_action("turn_left")
+        elif direction == "right":
+            return self.call_action("turn_right")
+        else:
+            raise FanException(
+                "Unsupported direction. Supported values: " + ", ".join(["left", "right"])
+            )
+
+
+class XiaomiFanP45(XiaomiFanMiot):
+    """Representation of the Xiaomi Smart Tower Fan 2 (xiaomi.fan.p45)."""
+
+    def __init__(self, name, device, model, unique_id, retries, preset_modes_override):
+        super().__init__(name, device, model, unique_id, retries, preset_modes_override)
+
+        self._device_features = FEATURE_FLAGS_FAN_P45
+        self._available_attributes = AVAILABLE_ATTRIBUTES_FAN_P45
+        self._percentage = None
+        self._preset_modes = list(FAN_PRESET_MODES_P45)
+        if preset_modes_override is not None:
+            self._preset_modes = preset_modes_override
+
+        self._preset_mode = None
+        self._oscillate = None
+        self._natural_mode = False
+
+        self._state_attrs = {
+            ATTR_MODEL: self._model,
+            **{attribute: None for attribute in self._available_attributes},
+        }
+
+    @property
+    def supported_features(self) -> int:
+        return (
+            FanEntityFeature.OSCILLATE
+            | FanEntityFeature.PRESET_MODE
+            | FanEntityFeature.SET_SPEED
+            | FanEntityFeature.TURN_OFF
+            | FanEntityFeature.TURN_ON
+        )
+
+    async def async_update(self):
+        if self._skip_update:
+            self._skip_update = False
+            return
+
+        try:
+            state = await self.hass.async_add_executor_job(self._device.status)
+            _LOGGER.debug("Got new state: %s", state)
+
+            self._available = True
+            self._percentage = state.fan_speed
+            self._oscillate = state.horizontal_swing
+            self._natural_mode = state.mode == OperationModeFanP45.Natural.name
+            self._state = state.power
+
+            if state.mode == OperationModeFanP45.Sleep.name:
+                self._preset_mode = FAN_PRESET_MODE_SLEEP
+            else:
+                for preset_mode, value in FAN_PRESET_MODES_P45.items():
+                    if preset_mode in (SPEED_OFF, FAN_PRESET_MODE_SLEEP):
+                        continue
+                    is_natural = preset_mode.startswith("Natural")
+                    if state.fan_level == value and is_natural == self._natural_mode:
+                        self._preset_mode = preset_mode
+                        break
+
+            self._state_attrs.update(
+                {
+                    key: self._extract_value_from_attribute(state, value)
+                    for key, value in self._available_attributes.items()
+                    if hasattr(state, value)
+                }
+            )
+            self._retry = 0
+
+        except DeviceException as ex:
+            self._retry = self._retry + 1
+            if self._retry < self._retries:
+                _LOGGER.info(
+                    "%s Got exception while fetching the state: %s , _retry=%s",
+                    self.__class__.__name__,
+                    ex,
+                    self._retry,
+                )
+            else:
+                self._available = False
+                _LOGGER.error(
+                    "%s Got exception while fetching the state: %s , _retry=%s",
+                    self.__class__.__name__,
+                    ex,
+                    self._retry,
+                )
+
+    @property
+    def percentage(self):
+        return self._percentage
+
+    @property
+    def preset_modes(self):
+        return self._preset_modes
+
+    @property
+    def preset_mode(self):
+        if self._state:
+            return self._preset_mode
+        return None
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set preset mode — combines level (1..4) with Straight/Natural mode,
+        or selects standalone Sleep mode."""
+        _LOGGER.debug("Setting the preset mode to: %s", preset_mode)
+
+        if preset_mode == SPEED_OFF:
+            await self.async_turn_off()
+            return
+
+        if not self._state:
+            await self._try_command("Turning the miio device on failed.", self._device.on)
+
+        if preset_mode == FAN_PRESET_MODE_SLEEP:
+            await self._try_command(
+                "Setting fan mode failed.",
+                self._device.set_mode,
+                OperationModeFanP45.Sleep,
+            )
+            return
+
+        natural = preset_mode.startswith("Natural")
+        await self._try_command(
+            "Setting fan mode failed.",
+            self._device.set_mode,
+            OperationModeFanP45.Natural if natural else OperationModeFanP45.Straight,
+        )
+        await self._try_command(
+            "Setting fan level of the miio device failed.",
+            self._device.set_fan_level,
+            FAN_PRESET_MODES_P45[preset_mode],
+        )
+
+    async def async_set_percentage(self, percentage: int) -> None:
+        _LOGGER.debug("Setting the fan speed percentage to: %s", percentage)
+
+        if percentage == 0:
+            await self.async_turn_off()
+            return
+
+        if not self._state:
+            await self._try_command("Turning the miio device on failed.", self._device.on)
+
+        await self._try_command(
+            "Setting fan speed percentage of the miio device failed.",
+            self._device.set_speed,
+            percentage,
+        )
+
+    async def async_set_natural_mode_on(self):
+        if self._device_features & FEATURE_SET_NATURAL_MODE == 0:
+            return
+        await self._try_command(
+            "Setting fan natural mode of the miio device failed.",
+            self._device.set_mode,
+            OperationModeFanP45.Natural,
+        )
+
+    async def async_set_natural_mode_off(self):
+        if self._device_features & FEATURE_SET_NATURAL_MODE == 0:
+            return
+        await self._try_command(
+            "Setting fan natural mode of the miio device failed.",
+            self._device.set_mode,
+            OperationModeFanP45.Straight,
+        )
 
 
 class OperationModeFanP76(Enum):


### PR DESCRIPTION
Implements the Xiaomi Smart Tower Fan 2 (model string `xiaomi.fan.p45`, retail SKU BHR8846EU) against the canonical MIoT spec at [urn:miot-spec-v2:device:fan:0000A005:xiaomi-p45:1:0000D062](https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:fan:0000A005:xiaomi-p45:1:0000D062).

Exposes power, mode (Straight/Natural/Sleep), fan-level 1..4 and fine-grained 1..100% speed, horizontal swing with all five included angles (30/60/90/120/150), child lock, indicator light, buzzer, off-delay timer (0..480 min), and turn-left/turn-right actions.

Refs [syssi/xiaomi_fan#282](https://github.com/syssi/xiaomi_fan/issues/282)

---

  How to try the PR branch

  - Fork branch: https://github.com/Blintmester/xiaomi_fan/tree/xiaomi.fan.p45
  - PR (draft): https://github.com/syssi/xiaomi_fan/pull/321

  Prerequisites
  - xiaomi_miio_fan HACS integration already installed and working on your Home Assistant.
  - Fan's LAN IP and 32-char token. Grab via Xiaomi Cloud Tokens Extractor (https://github.com/PiotrMachowski/Xiaomi-cloud-tokens-extractor) if missing.

  Install the PR build

  Option A - HACS:
  1. HACS -> three-dot menu -> Custom repositories -> add https://github.com/Blintmester/xiaomi_fan as Integration.
  2. Open Xiaomi Mi Smart Pedestal Fan in HACS -> Redownload -> pick the xiaomi.fan.p45 branch.
  3. Restart Home Assistant.

  Option B - manual swap:
  1. Stop Home Assistant.
  2. Back up `/config/custom_components/xiaomi_miio_fan/`.
  3. Replace with branch version:
  ```sh
  rm -rf /config/custom_components/xiaomi_miio_fan
  git clone -b xiaomi.fan.p45 https://github.com/Blintmester/xiaomi_fan.git /tmp/xfan
  cp -r /tmp/xfan/custom_components/xiaomi_miio_fan /config/custom_components/
  ```
  4. Start Home Assistant.

  Sanity check after install: `/config/custom_components/xiaomi_miio_fan/fan.py` should contain `MODEL_FAN_P45 = "xiaomi.fan.p45"`. If not, the swap didn't land - repeat the install step.

  Configure the fan
  
  Add to `configuration.yaml`, then restart:
  ```yaml
  fan:
    - platform: xiaomi_miio_fan
      name: Tower Fan 2
      host: 192.168.X.X        # fan's LAN IP
      token: !secret p45_token # 32-char token
      model: xiaomi.fan.p45
  ```

  The `model:` line is required - without it the integration won't pick the new code path.
  
  Enable debug logs so errors show raw MIoT payloads:
  ```yaml
  logger:
    default: info
    logs:
      custom_components.xiaomi_miio_fan: debug
      miio: debug
  ```

  Please test and report

  For each item: works / silently does nothing / throws. If it throws, paste relevant `home-assistant.log` lines.

  - Entity loads, state shows `on` / `off`.
  - Turn on / off.
  - `fan.set_percentage` across 1–100 (fine-grained speed actually changes, not just 4 steps).
  - Preset modes: `Level 1`–`Level 4`, `Natural 1`–`Natural 4`, `Sleep`.
  - Oscillation on / off.
  - Each swing angle: 30, 60, 90, 120, 150 (via `xiaomi_miio_fan.fan_set_oscillation_angle`). Note rejected values.
  - Child lock on / off.
  - LED on / off.
  - Buzzer on / off.
  - Off-delay timer (try 0, 30, 480 min).
  - Step left / step right via `xiaomi_miio_fan.fan_set_move`.
  - Entity attributes update after each change.

  Likely tweak spots (guessed from spec, no hardware):
  1. Swing angles - region-locked firmware may reject some of 30/60/90/120/150.
  2. `Sleep` preset - currently `mode=2` only; may need a level too.
  3. `turn_left` / `turn_right` action IDs (aiid 4 / 5).
  4. `fan_speed` (1–100) vs `fan_level` (1–4) - should not fight each other.

  Once confirmed on real hardware, I'll flip the PR out of draft.