### PR TITLE
Fix P70 delay off missing mapping

### DIFF
--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -3639,10 +3639,7 @@ class FanP70(MiotDevice):
         """Set delay off in minutes (0-480). 0 deactivates the timer."""
         if minutes < 0 or minutes > 480:
             raise FanException("Invalid value for a delayed turn off: %s" % minutes)
-        if minutes == 0:
-            return self.set_property("delay", False)
-        self.set_property("delay_time", minutes)
-        return self.set_property("delay", True)
+        return self.set_property("delay_time", minutes)
 
     def turn(self, direction: str):
         """Turn to the given direction."""


### PR DESCRIPTION
FanP70 only defines delay_time in its MIOT mapping, but delay_off() also tried to write to an unmapped "delay" property.

Since MiotDevice.set_property() resolves properties directly from the mapping, calling delay_off() for P70 could fail with a missing mapping key.

This changes P70 delay_off() to write delay_time directly, matching the P30/P76 implementation style.