### PR TITLE
Fix boolean LED brightness mapping

### DIFF
--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -3039,13 +3039,13 @@ class XiaomiFanP76(XiaomiFanP33):
         )
 
     async def async_set_led_brightness(self, brightness: int = 1):
-        """Set LED on (brightness > 0) or off (brightness == 0)."""
+        """Set LED on (brightness != 2) or off (brightness == 2)."""
         if self._device_features & FEATURE_SET_LED == 0:
             return
         await self._try_command(
             "Setting LED of the miio device failed.",
             self._device.set_light,
-            brightness > 0,
+            brightness != 2,
         )
 
     async def async_set_vertical_oscillation_on(self):
@@ -3426,13 +3426,13 @@ class XiaomiFanXiaomiP30(XiaomiFanP33):
         )
 
     async def async_set_led_brightness(self, brightness: int = 1):
-        """Set LED on (brightness > 0) or off (brightness == 0)."""
+        """Set LED on (brightness != 2) or off (brightness == 2)."""
         if self._device_features & FEATURE_SET_LED == 0:
             return
         await self._try_command(
             "Setting LED of the miio device failed.",
             self._device.set_light,
-            brightness > 0,
+            brightness != 2,
         )
 
     async def async_turn(self, direction: str):
@@ -3808,6 +3808,16 @@ class XiaomiFanP70(XiaomiFanP33):
             "Setting fan natural mode of the miio device failed.",
             self._device.set_mode,
             OperationModeFanP70.Straight,
+        )
+
+    async def async_set_led_brightness(self, brightness: int = 1):
+        """Set LED on (brightness != 2) or off (brightness == 2)."""
+        if self._device_features & FEATURE_SET_LED == 0:
+            return
+        await self._try_command(
+            "Setting LED of the miio device failed.",
+            self._device.set_light,
+            brightness != 2,
         )
 
     async def async_set_vertical_oscillation_on(self):


### PR DESCRIPTION
Fix boolean LED brightness handling for MIOT fan models.

The fan_set_led_brightness service documents brightness values as:
0 = Bright, 1 = Dim, 2 = Off.

Some MIOT models only expose a boolean LED property, so Bright and Dim should both keep the LED enabled, while Off should disable it.

P76 and Xiaomi P30 previously used brightness > 0, which turned Bright off and kept Off on. P70 also did not override the base LED brightness handler, so the service returned early because the model exposes FEATURE_SET_LED instead of FEATURE_SET_LED_BRIGHTNESS.

This changes boolean LED models to map brightness using brightness != 2.