### PR TITLE
Support percentage and preset mode in turn_on

### DIFF
--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -9,7 +9,7 @@ from enum import Enum
 from functools import partial
 import logging
 import math
-from typing import Any
+from typing import Any, Optional
 
 from homeassistant.components.fan import PLATFORM_SCHEMA, FanEntity, FanEntityFeature
 from homeassistant.const import (
@@ -881,27 +881,24 @@ class XiaomiGenericDevice(FanEntity):
             return False
 
     async def async_turn_on(
-        self,
-        percentage: int | None = None,
-        preset_mode: str | None = None,
-        **kwargs,
+            self,
+            percentage: Optional[int] = None,
+            preset_mode: Optional[str] = None,
+            **kwargs: Any,
     ) -> None:
         """Turn the device on."""
-        result = await self._try_command(
-            "Turning the miio device on failed.", self._device.on
-        )
-
-        if not result:
-            return
-
-        self._state = True
-        self._skip_update = True
 
         if percentage is not None:
             await self.async_set_percentage(percentage)
-
-        if preset_mode is not None:
+        elif preset_mode is not None:
             await self.async_set_preset_mode(preset_mode)
+        else:
+            await self._try_command(
+                "Turning the miio device on failed.", self._device.on
+            )
+
+        self._state = True
+        self._skip_update = True
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the device off."""

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -9,7 +9,7 @@ from enum import Enum
 from functools import partial
 import logging
 import math
-from typing import Any, Optional
+from typing import Any
 
 from homeassistant.components.fan import PLATFORM_SCHEMA, FanEntity, FanEntityFeature
 from homeassistant.const import (
@@ -881,10 +881,10 @@ class XiaomiGenericDevice(FanEntity):
             return False
 
     async def async_turn_on(
-            self,
-            percentage: Optional[int] = None,
-            preset_mode: Optional[str] = None,
-            **kwargs: Any,
+        self,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
     ) -> None:
         """Turn the device on."""
 

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -882,7 +882,6 @@ class XiaomiGenericDevice(FanEntity):
 
     async def async_turn_on(
         self,
-        speed: str | None = None,
         percentage: int | None = None,
         preset_mode: str | None = None,
         **kwargs,
@@ -895,14 +894,14 @@ class XiaomiGenericDevice(FanEntity):
         if not result:
             return
 
+        self._state = True
+        self._skip_update = True
+
         if percentage is not None:
             await self.async_set_percentage(percentage)
 
         if preset_mode is not None:
             await self.async_set_preset_mode(preset_mode)
-
-        self._state = True
-        self._skip_update = True
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the device off."""

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -881,18 +881,28 @@ class XiaomiGenericDevice(FanEntity):
             return False
 
     async def async_turn_on(
-        self, speed: str | None = None, mode: str | None = None, **kwargs
+        self,
+        speed: str | None = None,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs,
     ) -> None:
         """Turn the device on."""
         result = await self._try_command(
             "Turning the miio device on failed.", self._device.on
         )
-        if speed:
-            result = await self.async_set_speed(speed)
 
-        if result:
-            self._state = True
-            self._skip_update = True
+        if not result:
+            return
+
+        if percentage is not None:
+            await self.async_set_percentage(percentage)
+
+        if preset_mode is not None:
+            await self.async_set_preset_mode(preset_mode)
+
+        self._state = True
+        self._skip_update = True
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the device off."""


### PR DESCRIPTION
Support percentage and preset_mode in async_turn_on().

fan.turn_on can pass percentage or preset_mode, but these values were ignored by the integration.

This delegates them to the existing async_set_percentage() and async_set_preset_mode() handlers after turning the fan on.