### PR TITLE
Validate delay off service range

### DIFF
--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -565,7 +565,11 @@ SERVICE_SCHEMA_OSCILLATION_ANGLE = AIRPURIFIER_SERVICE_SCHEMA.extend(
 )
 
 SERVICE_SCHEMA_DELAY_OFF = AIRPURIFIER_SERVICE_SCHEMA.extend(
-    {vol.Required(ATTR_DELAY_OFF_COUNTDOWN): cv.positive_int}
+    {
+        vol.Required(ATTR_DELAY_OFF_COUNTDOWN): vol.All(
+            vol.Coerce(int), vol.Range(min=0, max=480)
+        )
+    }
 )
 
 SERVICE_SCHEMA_TURN = AIRPURIFIER_SERVICE_SCHEMA.extend(

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -567,7 +567,7 @@ SERVICE_SCHEMA_OSCILLATION_ANGLE = AIRPURIFIER_SERVICE_SCHEMA.extend(
 SERVICE_SCHEMA_DELAY_OFF = AIRPURIFIER_SERVICE_SCHEMA.extend(
     {
         vol.Required(ATTR_DELAY_OFF_COUNTDOWN): vol.All(
-            vol.Coerce(int), vol.Range(min=0, max=480)
+            vol.Coerce(int), vol.Range(min=0, max=600)
         )
     }
 )


### PR DESCRIPTION
Validate delay_off_countdown in the service schema.

The delay-off device methods only support values from 0 to 480 minutes, but the service schema accepted any non-negative integer.

This rejects invalid values before calling the device method, avoiding uncaught FanException errors from invalid service data.