### PR TITLE
Fix LED control for P5/P9/P10/P11/P15/P18/P30

### DIFF
--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -1400,6 +1400,16 @@ class XiaomiFanP5(XiaomiFan):
             delay_off_countdown,
         )
 
+    async def async_set_led_brightness(self, brightness: int = 2):
+        """Set LED on (brightness != 2) or off (brightness == 2)."""
+        if self._device_features & FEATURE_SET_LED == 0:
+            return
+        await self._try_command(
+            "Setting LED of the miio device failed.",
+            self._device.set_led,
+            brightness != 2,
+        )
+
 
 class XiaomiFanMiot(XiaomiFanP5):
     """Representation of a Xiaomi Pedestal Fan P9, P10, P11, P18, P30."""


### PR DESCRIPTION
Closes #189

`XiaomiFanP5` (and `XiaomiFanMiot` which is a passthrough subclass covering P9, P10, P11, P15, P18, P30) has `FEATURE_SET_LED` in its feature flags, but inherits `async_set_led_brightness` from `XiaomiFan`. That base implementation checks `FEATURE_SET_LED_BRIGHTNESS` — a flag these models don't have — so the guard always returns early and the LED can never be set.

Fix: override `async_set_led_brightness` in `XiaomiFanP5` using the same `brightness != 2` / `set_led` pattern already established for `XiaomiFan1C`.