### PR TITLE
Refine async_turn_on percentage handling

### DIFF
--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -950,21 +950,24 @@ class XiaomiGenericDevice(FanEntity):
         **kwargs: Any,
     ) -> None:
         """Turn the device on."""
-        result = await self._try_command(
-            "Turning the miio device on failed.", self._device.on
-        )
-
-        if not result:
+        if percentage == 0 or preset_mode == SPEED_OFF:
+            await self.async_turn_off(**kwargs)
             return
-
-        self._state = True
-        self._skip_update = True
 
         if percentage is not None:
             await self.async_set_percentage(percentage)
-
-        if preset_mode is not None:
+        elif preset_mode is not None:
             await self.async_set_preset_mode(preset_mode)
+        else:
+            result = await self._try_command(
+                "Turning the miio device on failed.", self._device.on
+            )
+
+            if not result:
+                return
+
+        self._state = True
+        self._skip_update = True
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the device off."""

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -950,18 +950,21 @@ class XiaomiGenericDevice(FanEntity):
         **kwargs: Any,
     ) -> None:
         """Turn the device on."""
+        result = await self._try_command(
+            "Turning the miio device on failed.", self._device.on
+        )
 
-        if percentage is not None:
-            await self.async_set_percentage(percentage)
-        elif preset_mode is not None:
-            await self.async_set_preset_mode(preset_mode)
-        else:
-            await self._try_command(
-                "Turning the miio device on failed.", self._device.on
-            )
+        if not result:
+            return
 
         self._state = True
         self._skip_update = True
+
+        if percentage is not None:
+            await self.async_set_percentage(percentage)
+
+        if preset_mode is not None:
+            await self.async_set_preset_mode(preset_mode)
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the device off."""


### PR DESCRIPTION
Fix async_turn_on() so it always turns the fan on before applying percentage or preset_mode.

The previous implementation delegated directly to async_set_percentage() or async_set_preset_mode() when those arguments were provided. Some implementations do not turn the device on from async_set_percentage(), so fan.turn_on with percentage could fail to actually power on the fan.

This keeps the turn_on call, updates the local state after it succeeds, and then applies percentage and/or preset_mode.