### PR TITLE
Add missing service metadata

### DIFF
--- a/custom_components/xiaomi_miio_fan/services.yaml
+++ b/custom_components/xiaomi_miio_fan/services.yaml
@@ -62,6 +62,22 @@ fan_set_led_brightness:
       description: Brightness (0 = Bright, 1 = Dim, 2 = Off)
       example: 1
 
+fan_set_raw_led_brightness:
+  name: Set raw LED brightness
+  description: Set the raw LED brightness.
+  fields:
+    entity_id:
+      name: Entity ID
+      description: Name of the Xiaomi Mi Smart Fan entity.
+      selector:
+        entity:
+          integration: xiaomi_miio_fan
+          domain: fan
+    brightness:
+      name: Brightness
+      description: Raw brightness value.
+      example: 1
+
 fan_set_natural_mode_on:
   name: Set natural mode on
   description: Turn the natural mode on.
@@ -77,6 +93,30 @@ fan_set_natural_mode_on:
 fan_set_natural_mode_off:
   name: Set natural mode off
   description: Turn the natural mode off.
+  fields:
+    entity_id:
+      name: Entity ID
+      description: Name of the Xiaomi Mi Smart Fan entity.
+      selector:
+        entity:
+          integration: xiaomi_miio_fan
+          domain: fan
+
+fan_set_anion_on:
+  name: Set anion on
+  description: Turn the ionizer on.
+  fields:
+    entity_id:
+      name: Entity ID
+      description: Name of the Xiaomi Mi Smart Fan entity.
+      selector:
+        entity:
+          integration: xiaomi_miio_fan
+          domain: fan
+
+fan_set_anion_off:
+  name: Set anion off
+  description: Turn the ionizer off.
   fields:
     entity_id:
       name: Entity ID

--- a/custom_components/xiaomi_miio_fan/strings.json
+++ b/custom_components/xiaomi_miio_fan/strings.json
@@ -54,6 +54,20 @@
         }
       }
     },
+    "fan_set_raw_led_brightness": {
+      "name": "Set raw LED brightness",
+      "description": "Set the raw LED brightness.",
+      "fields": {
+        "entity_id": {
+          "name": "Entity ID",
+          "description": "Name of the Xiaomi Mi Smart Fan entity."
+        },
+        "brightness": {
+          "name": "Brightness",
+          "description": "Raw brightness value."
+        }
+      }
+    },
     "fan_set_natural_mode_on": {
       "name": "Set natural mode on",
       "description": "Turn the natural mode on.",
@@ -67,6 +81,26 @@
     "fan_set_natural_mode_off": {
       "name": "Set natural mode off",
       "description": "Turn the natural mode off.",
+      "fields": {
+        "entity_id": {
+          "name": "Entity ID",
+          "description": "Name of the Xiaomi Mi Smart Fan entity."
+        }
+      }
+    },
+    "fan_set_anion_on": {
+      "name": "Set anion on",
+      "description": "Turn the ionizer on.",
+      "fields": {
+        "entity_id": {
+          "name": "Entity ID",
+          "description": "Name of the Xiaomi Mi Smart Fan entity."
+        }
+      }
+    },
+    "fan_set_anion_off": {
+      "name": "Set anion off",
+      "description": "Turn the ionizer off.",
       "fields": {
         "entity_id": {
           "name": "Entity ID",


### PR DESCRIPTION
Add missing service metadata for registered services.

fan_set_raw_led_brightness, fan_set_anion_on and fan_set_anion_off are registered by the integration, but were missing from services.yaml and strings.json.