### PR TITLE
Validate raw LED brightness range

### DIFF
--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -628,7 +628,11 @@ SERVICE_SCHEMA_LED_BRIGHTNESS = AIRPURIFIER_SERVICE_SCHEMA.extend(
 )
 
 SERVICE_SCHEMA_RAW_LED_BRIGHTNESS = AIRPURIFIER_SERVICE_SCHEMA.extend(
-    {vol.Required(ATTR_BRIGHTNESS): vol.Coerce(int)}
+    {
+        vol.Required(ATTR_BRIGHTNESS): vol.All(
+            vol.Coerce(int), vol.Range(min=0, max=100)
+        )
+    }
 )
 
 SERVICE_SCHEMA_OSCILLATION_ANGLE = AIRPURIFIER_SERVICE_SCHEMA.extend(

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -628,11 +628,7 @@ SERVICE_SCHEMA_LED_BRIGHTNESS = AIRPURIFIER_SERVICE_SCHEMA.extend(
 )
 
 SERVICE_SCHEMA_RAW_LED_BRIGHTNESS = AIRPURIFIER_SERVICE_SCHEMA.extend(
-    {
-        vol.Required(ATTR_BRIGHTNESS): vol.All(
-            vol.Coerce(int), vol.Range(min=0, max=100)
-        )
-    }
+    {vol.Required(ATTR_BRIGHTNESS): vol.All(vol.Coerce(int), vol.Range(min=0, max=100))}
 )
 
 SERVICE_SCHEMA_OSCILLATION_ANGLE = AIRPURIFIER_SERVICE_SCHEMA.extend(


### PR DESCRIPTION
Validate raw LED brightness values in the service schema.

The raw LED brightness service accepted any integer, but the device method only supports values from 0 to 100 and raises FanException for invalid values.

This adds schema validation so invalid brightness values are rejected before calling the device method.