### PR TITLE
Catch FanException separately to avoid marking device unavailable

### DIFF
--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -938,6 +938,9 @@ class XiaomiGenericDevice(FanEntity):
             _LOGGER.debug("Response received from miio device: %s", result)
 
             return result == SUCCESS
+        except FanException as exc:
+            _LOGGER.error(mask_error, exc)
+            return False
         except DeviceException as exc:
             _LOGGER.error(mask_error, exc)
             self._available = False

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -939,7 +939,7 @@ class XiaomiGenericDevice(FanEntity):
 
             return result == SUCCESS
         except FanException as exc:
-            _LOGGER.error(mask_error, exc)
+            _LOGGER.warning(mask_error, exc)
             return False
         except DeviceException as exc:
             _LOGGER.error(mask_error, exc)


### PR DESCRIPTION
`FanException` is a subclass of `DeviceException`, so it was already caught — but by the wrong handler: the `DeviceException` block sets `self._available = False`, which flags the device as offline in HA. This is incorrect for `FanException`, which covers validation failures and unsupported commands (bad angle value, unsupported mode, etc.) rather than connectivity problems.

This PR catches `FanException` before `DeviceException` so those errors:
- are logged at `warning` level (expected, user-recoverable) rather than `error`
- do **not** mark the device unavailable
- still return `False` to the caller