### PR TITLE
Fix LED control for dmaker.fan.p33 and dmaker.fan.p45

### DIFF
--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -3061,6 +3061,10 @@ class FanP45(MiotDevice):
         """Set indicator state."""
         return self.set_property("led", bool(light))
 
+    def set_led(self, led: bool):
+        """Set indicator state through the common fan LED interface."""
+        return self.set_light(led)
+
     def delay_off(self, minutes: int):
         """Set delayed turn-off in minutes (0..480; 0 disables)."""
         if minutes < 0 or minutes > 480:

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -2534,6 +2534,10 @@ class FanP33(MiotDevice):
         """Set indicator state."""
         return self.set_property("light", light)
 
+    def set_led(self, led: bool):
+        """Set indicator state through the common fan LED interface."""
+        return self.set_light(led)
+
     def set_mode(self, mode: OperationModeFanP33):
         """Set mode."""
         return self.set_property("mode", OperationModeFanP33[mode.name].value)


### PR DESCRIPTION
## Summary

- add the common `set_led()` interface to `FanP33`
- delegate to the existing `set_light()` implementation

## Problem

`XiaomiFanP5.async_set_led_brightness()` calls `self._device.set_led()`. `FanP33` exposes the LED state and implements `set_light()`, but does not implement `set_led()`. As a result, calling `xiaomi_miio_fan.fan_set_led_brightness` for `dmaker.fan.p33` fails with:

```text
'FanP33' object has no attribute 'set_led'
```

## Fix

Add a small compatibility method to `FanP33` that forwards `set_led(led)` to `set_light(led)`. This preserves the existing method while matching the interface expected by the Home Assistant entity implementation.

## Validation

- reproduced through the Home Assistant service on a real `dmaker.fan.p33`
- `python3 -m py_compile custom_components/xiaomi_miio_fan/fan.py`
- `ruff check custom_components/xiaomi_miio_fan/fan.py`
- `git diff --check`
