### PR TITLE
Add Xiaomi Smart Standing Fan Pro Slim 2 (xiaomi.fan.p43) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Credits: Thanks to [Rytilahti](https://github.com/rytilahti/python-miio) for all
 | Xiaomi Smart Desktop Air Circulation Fan  | xiaomi.fan.p70 | - | - |
 | Mi Smart Standing Fan 2 Lite              | xiaomi.fan.2lite | - | - |
 | Xiaomi Smart Standing Fan Pro Slim        | xiaomi.fan.p85 | - | - |
+| Xiaomi Smart Standing Fan Pro Slim 2       | xiaomi.fan.p43 | - | - |
 
 
 ## Features

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -71,6 +71,7 @@ MODEL_FAN_XIAOMI_P30 = "xiaomi.fan.p30"  # Mi/Xiaomi Smart Standing Fan 2 P30
 MODEL_FAN_P76 = "xiaomi.fan.p76"  # Xiaomi Smart Standing Air Circulation Fan
 MODEL_FAN_P70 = "xiaomi.fan.p70"  # Smart Desktop Air Circulation Fan
 MODEL_FAN_P85 = "xiaomi.fan.p85"  # Xiaomi Smart Standing Fan Pro Slim
+MODEL_FAN_P43 = "xiaomi.fan.p43"  # Xiaomi Smart Standing Fan Pro Slim 2
 MODEL_FAN_2LITE = "xiaomi.fan.2lite"  # Mi Smart Standing Fan 2 Lite
 MODEL_FAN_LESHOW_SS4 = "leshow.fan.ss4"
 MODEL_FAN_1C = "dmaker.fan.1c"  # Pedestal Fan Fan 1C
@@ -104,6 +105,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
                 MODEL_FAN_P76,
                 MODEL_FAN_P70,
                 MODEL_FAN_P85,
+                MODEL_FAN_P43,
                 MODEL_FAN_2LITE,
                 MODEL_FAN_LESHOW_SS4,
                 MODEL_FAN_1C,
@@ -261,6 +263,17 @@ AVAILABLE_ATTRIBUTES_FAN_2LITE = {
 }
 
 AVAILABLE_ATTRIBUTES_FAN_P85 = {
+    ATTR_MODE: "mode",
+    ATTR_OSCILLATE: "horizontal_swing",
+    ATTR_ANGLE: "horizontal_swing_angle",
+    ATTR_DELAY_OFF_COUNTDOWN: "delay_time",
+    ATTR_LED: "led",
+    ATTR_BUZZER: "buzzer",
+    ATTR_CHILD_LOCK: "child_lock",
+    ATTR_RAW_SPEED: "fan_speed",
+}
+
+AVAILABLE_ATTRIBUTES_FAN_P43 = {
     ATTR_MODE: "mode",
     ATTR_OSCILLATE: "horizontal_swing",
     ATTR_ANGLE: "horizontal_swing_angle",
@@ -453,6 +466,18 @@ FAN_PRESET_MODES_P85 = {
     FAN_SPEED_NATURAL4: 4,
 }
 
+FAN_PRESET_MODES_P43 = {
+    SPEED_OFF: -1,
+    FAN_SPEED_LEVEL1: 1,
+    FAN_SPEED_LEVEL2: 2,
+    FAN_SPEED_LEVEL3: 3,
+    FAN_SPEED_LEVEL4: 4,
+    FAN_SPEED_NATURAL1: 1,
+    FAN_SPEED_NATURAL2: 2,
+    FAN_SPEED_NATURAL3: 3,
+    FAN_SPEED_NATURAL4: 4,
+}
+
 FAN_PRESET_MODE_SLEEP = "Sleep"
 
 # Smart Tower Fan 2 (xiaomi.fan.p45) — fan-level enum: Level1..Level4 (1..4).
@@ -596,6 +621,15 @@ FEATURE_FLAGS_FAN_2LITE = (
 )
 
 FEATURE_FLAGS_FAN_P85 = (
+    FEATURE_SET_BUZZER
+    | FEATURE_SET_CHILD_LOCK
+    | FEATURE_SET_LED
+    | FEATURE_SET_OSCILLATION_ANGLE
+    | FEATURE_SET_NATURAL_MODE
+    | FEATURE_TURN
+)
+
+FEATURE_FLAGS_FAN_P43 = (
     FEATURE_SET_BUZZER
     | FEATURE_SET_CHILD_LOCK
     | FEATURE_SET_LED
@@ -812,6 +846,11 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     elif model == MODEL_FAN_P85:
         fan = FanP85(host, token, model=model)
         device = XiaomiFanP85(
+            name, fan, model, unique_id, retries, preset_modes_override
+        )
+    elif model == MODEL_FAN_P43:
+        fan = FanP43(host, token, model=model)
+        device = XiaomiFanP43(
             name, fan, model, unique_id, retries, preset_modes_override
         )
     elif model == MODEL_FAN_2LITE:
@@ -5104,3 +5143,232 @@ class XiaomiFanP85(XiaomiFanP33):
             self._device.turn,
             direction,
         )
+
+OperationModeFanP43 = OperationModeFanP70
+
+
+class FanStatusP43(FanStatusP70):
+    """Container for status reports for FanP43."""
+
+
+class FanP43(FanP70):
+    """Main class representing the Xiaomi Fan P43 (xiaomi.fan.p43)."""
+
+    mapping = {
+        # urn:miot-spec-v2:device:fan:0000A005:xiaomi-p43:1
+        "power": {"siid": 2, "piid": 1},
+        "mode": {"siid": 2, "piid": 3},
+        "fan_level": {"siid": 2, "piid": 2},
+        "horizontal_swing": {"siid": 2, "piid": 4},
+        "horizontal_swing_angle": {"siid": 2, "piid": 5},
+        "led": {"siid": 4, "piid": 1},
+        "buzzer": {"siid": 5, "piid": 1},
+        "child_lock": {"siid": 6, "piid": 1},
+        "delay": {"siid": 3, "piid": 1},
+        "delay_time": {"siid": 3, "piid": 2},
+        "delay_remain_time": {"siid": 3, "piid": 3},
+        "fan_speed": {"siid": 2, "piid": 6},
+        "toggle": {"siid": 2, "aiid": 1},
+        "turn_left": {"siid": 2, "aiid": 2},
+        "turn_right": {"siid": 2, "aiid": 3},
+    }
+
+
+    def __init__(
+        self,
+        ip: str = None,
+        token: str = None,
+        start_id: int = 0,
+        debug: int = 0,
+        lazy_discover: bool = True,
+        timeout: int = 5,
+        model: str = MODEL_FAN_P43,
+    ):
+        super().__init__(ip, token, start_id, debug, lazy_discover, timeout, model=model)
+
+    def status(self):
+        """Retrieve properties."""
+        return FanStatusP43(
+            {
+                prop["did"]: prop["value"] if prop["code"] == 0 else None
+                for prop in self.get_properties_for_mapping()
+            }
+        )
+
+    def set_fan_level(self, fan_level: int):
+        """Set fan level (1-4)."""
+        if fan_level not in [1, 2, 3, 4]:
+            raise FanException("Invalid fan level: %s" % fan_level)
+        return self.set_property("fan_level", fan_level)
+
+    def set_angle(self, angle: int):
+        """Set the horizontal oscillation angle."""
+        if angle not in [30, 60, 90]:
+            raise FanException(
+                "Unsupported angle. Supported values: "
+                + ", ".join(str(i) for i in [30, 60, 90])
+            )
+        return self.set_property("horizontal_swing_angle", angle)
+
+    def turn(self, direction: str):
+        """Turn to the given direction."""
+        if direction == "left":
+            return self.call_action("turn_left")
+        elif direction == "right":
+            return self.call_action("turn_right")
+        else:
+            raise FanException(
+                "Unsupported direction. Supported values: left, right"
+            )
+
+
+class XiaomiFanP43(XiaomiFanP33):
+    """Representation of a Xiaomi Fan P43 (Xiaomi Smart Standing Fan Pro Slim)."""
+
+    def __init__(self, name, device, model, unique_id, retries, preset_modes_override):
+        super().__init__(name, device, model, unique_id, retries, preset_modes_override)
+
+        self._device_features = FEATURE_FLAGS_FAN_P43
+        self._available_attributes = AVAILABLE_ATTRIBUTES_FAN_P43
+        self._percentage = None
+        self._preset_modes = list(FAN_PRESET_MODES_P43)
+        if preset_modes_override is not None:
+            self._preset_modes = preset_modes_override
+
+        self._preset_mode = None
+        self._oscillate = None
+        self._natural_mode = False
+
+        self._state_attrs = {
+            ATTR_MODEL: self._model,
+            **{attribute: None for attribute in self._available_attributes},
+        }
+
+    @property
+    def supported_features(self) -> int:
+        return (
+            FanEntityFeature.OSCILLATE
+            | FanEntityFeature.PRESET_MODE
+            | FanEntityFeature.SET_SPEED
+            | FanEntityFeature.TURN_OFF
+            | FanEntityFeature.TURN_ON
+        )
+
+    async def async_update(self):
+        if self._skip_update:
+            self._skip_update = False
+            return
+
+        try:
+            state = await self.hass.async_add_executor_job(self._device.status)
+            _LOGGER.debug("Got new state: %s", state)
+
+            self._available = True
+            self._percentage = state.fan_speed
+            self._oscillate = state.horizontal_swing
+            self._natural_mode = state.mode == OperationModeFanP43.Natural.name
+            self._state = state.power
+
+            for preset_mode, value in FAN_PRESET_MODES_P43.items():
+                if preset_mode == SPEED_OFF:
+                    continue
+                is_natural = preset_mode.startswith("Natural")
+                if state.fan_level == value and is_natural == self._natural_mode:
+                    self._preset_mode = preset_mode
+                    break
+
+            self._state_attrs.update(
+                {
+                    key: self._extract_value_from_attribute(state, value)
+                    for key, value in self._available_attributes.items()
+                    if hasattr(state, value)
+                }
+            )
+            self._retry = 0
+
+        except DeviceException as ex:
+            self._retry = self._retry + 1
+            if self._retry < self._retries:
+                _LOGGER.info(
+                    "%s Got exception while fetching the state: %s , _retry=%s",
+                    self.__class__.__name__,
+                    ex,
+                    self._retry,
+                )
+            else:
+                self._available = False
+                _LOGGER.error(
+                    "%s Got exception while fetching the state: %s , _retry=%s",
+                    self.__class__.__name__,
+                    ex,
+                    self._retry,
+                )
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        _LOGGER.debug("Setting the preset mode to: %s", preset_mode)
+
+        if preset_mode == SPEED_OFF:
+            await self.async_turn_off()
+            return
+
+        if not self._state:
+            await self._try_command(
+                "Turning the miio device on failed.", self._device.on
+            )
+
+        natural = preset_mode.startswith("Natural")
+        await self._try_command(
+            "Setting fan mode failed.",
+            self._device.set_mode,
+            OperationModeFanP43.Natural if natural else OperationModeFanP43.Straight,
+        )
+        await self._try_command(
+            "Setting fan level of the miio device failed.",
+            self._device.set_fan_level,
+            FAN_PRESET_MODES_P43[preset_mode],
+        )
+
+    async def async_set_natural_mode_on(self):
+        if self._device_features & FEATURE_SET_NATURAL_MODE == 0:
+            return
+        await self._try_command(
+            "Setting fan natural mode of the miio device failed.",
+            self._device.set_mode,
+            OperationModeFanP43.Natural,
+        )
+
+    async def async_set_natural_mode_off(self):
+        if self._device_features & FEATURE_SET_NATURAL_MODE == 0:
+            return
+        await self._try_command(
+            "Setting fan natural mode of the miio device failed.",
+            self._device.set_mode,
+            OperationModeFanP43.Straight,
+        )
+
+    async def async_set_delay_off(self, delay_off_countdown: int) -> None:
+        await self._try_command(
+            "Setting delay off miio device failed.",
+            self._device.delay_off,
+            delay_off_countdown,
+        )
+
+    async def async_set_led_brightness(self, brightness: int = 1):
+        """Set LED on (brightness != 2) or off (brightness == 2)."""
+        if self._device_features & FEATURE_SET_LED == 0:
+            return
+        await self._try_command(
+            "Setting LED of the miio device failed.",
+            self._device.set_light,
+            brightness != 2,
+        )
+
+    async def async_turn(self, direction: str):
+        if self._device_features & FEATURE_TURN == 0:
+            return
+        await self._try_command(
+            "Turning the miio device failed.",
+            self._device.turn,
+            direction,
+        )
+

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -5144,6 +5144,7 @@ class XiaomiFanP85(XiaomiFanP33):
             direction,
         )
 
+
 OperationModeFanP43 = OperationModeFanP70
 
 
@@ -5173,18 +5174,20 @@ class FanP43(FanP70):
         "turn_right": {"siid": 2, "aiid": 3},
     }
 
-
     def __init__(
         self,
-        ip: str = None,
-        token: str = None,
+        ip: str | None = None,
+        token: str | None = None,
         start_id: int = 0,
         debug: int = 0,
         lazy_discover: bool = True,
         timeout: int = 5,
         model: str = MODEL_FAN_P43,
-    ):
-        super().__init__(ip, token, start_id, debug, lazy_discover, timeout, model=model)
+    ) -> None:
+        """Initialize."""
+        super().__init__(
+            ip, token, start_id, debug, lazy_discover, timeout, model=model
+        )
 
     def status(self):
         """Retrieve properties."""
@@ -5198,7 +5201,7 @@ class FanP43(FanP70):
     def set_fan_level(self, fan_level: int):
         """Set fan level (1-4)."""
         if fan_level not in [1, 2, 3, 4]:
-            raise FanException("Invalid fan level: %s" % fan_level)
+            raise FanException(f"Invalid fan level: {fan_level}")
         return self.set_property("fan_level", fan_level)
 
     def set_angle(self, angle: int):
@@ -5217,15 +5220,14 @@ class FanP43(FanP70):
         elif direction == "right":
             return self.call_action("turn_right")
         else:
-            raise FanException(
-                "Unsupported direction. Supported values: left, right"
-            )
+            raise FanException("Unsupported direction. Supported values: left, right")
 
 
 class XiaomiFanP43(XiaomiFanP33):
     """Representation of a Xiaomi Fan P43 (Xiaomi Smart Standing Fan Pro Slim)."""
 
     def __init__(self, name, device, model, unique_id, retries, preset_modes_override):
+        """Initialize the fan entity."""
         super().__init__(name, device, model, unique_id, retries, preset_modes_override)
 
         self._device_features = FEATURE_FLAGS_FAN_P43
@@ -5246,6 +5248,7 @@ class XiaomiFanP43(XiaomiFanP33):
 
     @property
     def supported_features(self) -> int:
+        """Return supported features."""
         return (
             FanEntityFeature.OSCILLATE
             | FanEntityFeature.PRESET_MODE
@@ -5255,6 +5258,7 @@ class XiaomiFanP43(XiaomiFanP33):
         )
 
     async def async_update(self):
+        """Fetch state from the device."""
         if self._skip_update:
             self._skip_update = False
             return
@@ -5305,6 +5309,7 @@ class XiaomiFanP43(XiaomiFanP33):
                 )
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set the preset mode of the fan."""
         _LOGGER.debug("Setting the preset mode to: %s", preset_mode)
 
         if preset_mode == SPEED_OFF:
@@ -5329,6 +5334,7 @@ class XiaomiFanP43(XiaomiFanP33):
         )
 
     async def async_set_natural_mode_on(self):
+        """Turn the natural mode on."""
         if self._device_features & FEATURE_SET_NATURAL_MODE == 0:
             return
         await self._try_command(
@@ -5338,6 +5344,7 @@ class XiaomiFanP43(XiaomiFanP33):
         )
 
     async def async_set_natural_mode_off(self):
+        """Turn the natural mode off."""
         if self._device_features & FEATURE_SET_NATURAL_MODE == 0:
             return
         await self._try_command(
@@ -5347,6 +5354,7 @@ class XiaomiFanP43(XiaomiFanP33):
         )
 
     async def async_set_delay_off(self, delay_off_countdown: int) -> None:
+        """Set delay off countdown."""
         await self._try_command(
             "Setting delay off miio device failed.",
             self._device.delay_off,
@@ -5364,6 +5372,7 @@ class XiaomiFanP43(XiaomiFanP33):
         )
 
     async def async_turn(self, direction: str):
+        """Turn fan in the given direction."""
         if self._device_features & FEATURE_TURN == 0:
             return
         await self._try_command(
@@ -5371,4 +5380,3 @@ class XiaomiFanP43(XiaomiFanP33):
             self._device.turn,
             direction,
         )
-

--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -5361,7 +5361,7 @@ class XiaomiFanP43(XiaomiFanP33):
             delay_off_countdown,
         )
 
-    async def async_set_led_brightness(self, brightness: int = 1):
+    async def async_set_led_brightness(self, brightness: int = 2):
         """Set LED on (brightness != 2) or off (brightness == 2)."""
         if self._device_features & FEATURE_SET_LED == 0:
             return

--- a/custom_components/xiaomi_miio_fan/services.yaml
+++ b/custom_components/xiaomi_miio_fan/services.yaml
@@ -184,7 +184,7 @@ fan_set_vertical_oscillation_off:
 
 fan_turn:
   name: Turn
-  description: Turn to the given direction. (P30, P70, P76 and P85)
+  description: Turn to the given direction. (P30, P70, P76, P85, ans P43)
   fields:
     entity_id:
       name: Entity ID

--- a/custom_components/xiaomi_miio_fan/services.yaml
+++ b/custom_components/xiaomi_miio_fan/services.yaml
@@ -184,7 +184,7 @@ fan_set_vertical_oscillation_off:
 
 fan_turn:
   name: Turn
-  description: Turn to the given direction. (P30, P70, P76, P85, ans P43)
+  description: Turn to the given direction. (P30, P70, P76, P85, and P43)
   fields:
     entity_id:
       name: Entity ID

--- a/custom_components/xiaomi_miio_fan/strings.json
+++ b/custom_components/xiaomi_miio_fan/strings.json
@@ -158,7 +158,7 @@
     },
     "fan_turn": {
       "name": "Turn",
-      "description": "Turn to the given direction. (P76 and P85)",
+      "description": "Turn to the given direction. (P76, P85, and P43)",
       "fields": {
         "entity_id": {
           "name": "Entity ID",


### PR DESCRIPTION
Basically I copied the work of @geirra and modified the mapping according to the specs here [https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:fan:0000A005:xiaomi-p43:1](url).

I'm not a Developer, so this is copied and pasted from a local copy I was working on when I found out that on/off works if I force the model to be teh p85 for my p43.

I hope there are no mistakes due to my pasting. The fan.py I have modified for my Home Asisstant Works as expected.