### PR TITLE
Fix delay-off maximum value

### DIFF
--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -718,7 +718,7 @@ SERVICE_SCHEMA_OSCILLATION_ANGLE = AIRPURIFIER_SERVICE_SCHEMA.extend(
 SERVICE_SCHEMA_DELAY_OFF = AIRPURIFIER_SERVICE_SCHEMA.extend(
     {
         vol.Required(ATTR_DELAY_OFF_COUNTDOWN): vol.All(
-            vol.Coerce(int), vol.Range(min=0, max=600)
+            vol.Coerce(int), vol.Range(min=0, max=480)
         )
     }
 )


### PR DESCRIPTION
## Summary

Align the delay-off service validation with the range supported by the fan implementations.

## Problem

The service schema allowed values up to 600 minutes, while the MIoT fan implementations reject values above 480 minutes.

This meant Home Assistant could accept values that the device would later reject.