### PR TITLE
Fix Fan 1C percentage reporting

### DIFF
--- a/custom_components/xiaomi_miio_fan/fan.py
+++ b/custom_components/xiaomi_miio_fan/fan.py
@@ -1740,6 +1740,8 @@ class XiaomiFan1C(XiaomiFan):
     @property
     def percentage(self) -> int | None:
         """Return the current speed percentage."""
+        if self._preset_mode not in FAN_SPEEDS_1C:
+            return None
         return ordered_list_item_to_percentage(FAN_SPEEDS_1C, self._preset_mode)
 
     @property


### PR DESCRIPTION
## Summary

Prevent percentage reporting from raising an exception for Fan 1C devices when no valid speed preset is available.

## Problem

`XiaomiFan1C.percentage` converted the current preset using `FAN_SPEEDS_1C` without checking whether the preset was present in that list.

`FAN_SPEEDS_1C` excludes the `off` preset, and the current preset may also be `None` before the first successful update.

In those states, the percentage conversion could raise `ValueError`.